### PR TITLE
ATDD Story 0.3: session store and refresh rotation red-phase suite

### DIFF
--- a/_bmad-output/test-artifacts/atdd-checklist-0-3.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-0-3.md
@@ -1,0 +1,261 @@
+---
+stepsCompleted: ['step-01-preflight-and-context','step-02-generation-mode','step-03-test-strategy','step-04-generate-tests','step-04c-aggregate','step-05-validate-and-complete']
+lastStep: 'step-05-validate-and-complete'
+lastSaved: '2026-02-17'
+---
+
+# ATDD Checklist - Epic 0, Story 3: Platform session store and refresh rotation
+
+**Date:** 2026-02-17
+**Author:** Jeremiah
+**Primary Test Level:** API
+
+---
+
+## Story Summary
+
+Story 0.3 hardens session security by requiring first-party refresh session persistence with auditable metadata and strict refresh rotation semantics. The RED-phase test suite defines deterministic rejection behavior for replayed and revoked refresh tokens before implementation begins.
+
+**As a** security engineer
+**I want** first-party session persistence with refresh rotation
+**So that** token lifecycle and revocation are auditable and safe
+
+---
+
+## Acceptance Criteria
+
+1. `platform.sessions` stores hashed refresh state, expiry, and revocation metadata.
+2. replayed/revoked refresh tokens are rejected.
+
+---
+
+## Failing Tests Created (RED Phase)
+
+### API Tests (4 tests)
+
+**File:** `tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+
+- ✅ **Test:** persists hashed refresh state with expiry and revocation metadata `@P0`
+  - **Status:** RED - refresh session issue contract is not implemented yet.
+  - **Verifies:** hashed refresh state + expiry/revocation metadata persistence in `platform.sessions`.
+
+- ✅ **Test:** rotates refresh sessions and revokes prior refresh state atomically `@P0`
+  - **Status:** RED - rotation contract is not implemented yet.
+  - **Verifies:** prior refresh token state is revoked and replacement token metadata is persisted.
+
+- ✅ **Test:** rejects replayed refresh token attempts deterministically `@P1`
+  - **Status:** RED - replay detection semantics are not implemented yet.
+  - **Verifies:** replayed refresh tokens are refused with deterministic security refusal code.
+
+- ✅ **Test:** rejects revoked refresh tokens across subsequent refresh attempts `@P1`
+  - **Status:** RED - revoked-token refusal path is not implemented yet.
+  - **Verifies:** revoked refresh credentials cannot be reused.
+
+### E2E Tests (3 tests)
+
+**File:** `tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts`
+
+- ✅ **Test:** shows active refresh session metadata after authenticated entry `@P0`
+  - **Status:** RED - security session panel behavior is not implemented yet.
+  - **Verifies:** refresh hash/expiry/revocation fields are visible in user security journey.
+
+- ✅ **Test:** rotates refresh token and replaces prior session card in security journey `@P0`
+  - **Status:** RED - UI/session rotation flow is not implemented yet.
+  - **Verifies:** prior token is marked revoked and replacement token is active.
+
+- ✅ **Test:** blocks replayed or revoked refresh actions with deterministic refusal banner `@P1`
+  - **Status:** RED - refusal-banner behavior is not implemented yet.
+  - **Verifies:** replay/revocation rejections surface deterministic refusal codes in UI flow.
+
+### Component Tests (0 tests)
+
+No component tests are required for this platform-kernel security story.
+
+---
+
+## Data Factories Created
+
+### Session Rotation Factory
+
+**File:** `tests/support/factories/sessionRotationFactory.ts`
+
+**Exports:**
+
+- `createSessionHeaders(overrides?)` - builds tenant/auth/correlation/csrf header sets.
+- `createRefreshIssuePayload(overrides?)` - builds payload for refresh-session issue contract.
+- `createRefreshRotatePayload(overrides?)` - builds payload for refresh rotation contract.
+- `createRefreshRevokePayload(overrides?)` - builds payload for explicit refresh revocation contract.
+
+---
+
+## Fixtures Created
+
+### Session Rotation Fixture
+
+**File:** `tests/support/fixtures/sessionRotation.fixture.ts`
+
+**Fixtures:**
+
+- `sessionHeaders` - generated request headers with tenant/auth context.
+- `refreshIssuePayload` - generated issue payload test data.
+- `refreshRotatePayload` - generated rotate payload test data.
+- `refreshRevokePayload` - generated revoke payload test data.
+
+---
+
+## Mock Requirements
+
+No third-party mocks required. Story targets platform kernel session contracts and first-party refresh security semantics.
+
+---
+
+## Required data-testid Attributes
+
+### Login + Security Session UI
+
+- `auth-email-input` - login email input.
+- `auth-password-input` - login password input.
+- `session-store-panel` - session security panel container.
+- `refresh-token-hash` - active refresh hash display field.
+- `refresh-token-expires-at` - refresh expiry display field.
+- `refresh-token-revoked-at` - refresh revocation status field.
+- `session-rotation-toast` - rotation success signal.
+- `previous-refresh-token-status` - previous refresh status label.
+- `active-refresh-token-status` - active refresh status label.
+- `session-refusal-banner` - replay/revoke refusal container.
+- `session-refusal-code` - deterministic refusal code display element.
+
+---
+
+## Implementation Checklist
+
+### Test: persists hashed refresh state with expiry and revocation metadata
+
+**File:** `tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+
+**Tasks to make this test pass:**
+
+- [ ] Implement `POST /api/v1/platform/_kernel/sessions/refresh/issue`.
+- [ ] Persist hashed refresh token state in `platform.sessions` (never raw token).
+- [ ] Persist `refreshTokenExpiresAt` and `revokedAt` metadata fields.
+- [ ] Return deterministic success envelope for created session metadata.
+- [ ] Run test: `npm run test:e2e -- tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+- [ ] ✅ Test passes (green phase)
+
+**Estimated Effort:** 3-5 hours
+
+### Test: rotates refresh sessions and revokes prior refresh state atomically
+
+**File:** `tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+
+**Tasks to make this test pass:**
+
+- [ ] Implement `POST /api/v1/platform/_kernel/sessions/refresh/rotate`.
+- [ ] Revoke prior refresh record and persist replacement refresh hash atomically.
+- [ ] Emit audit-ready rotation metadata (`priorRevokedAt`, replacement session linkage).
+- [ ] Run test: `npm run test:e2e -- tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+- [ ] ✅ Test passes (green phase)
+
+**Estimated Effort:** 3-6 hours
+
+### Test: rejects replayed refresh token attempts deterministically
+
+**File:** `tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+
+**Tasks to make this test pass:**
+
+- [ ] Detect replayed refresh token use against rotated/revoked state.
+- [ ] Return deterministic refusal envelope `REFRESH_TOKEN_REPLAY_DETECTED`.
+- [ ] Ensure refusal uses security refusal type + stable status code.
+- [ ] Run test: `npm run test:e2e -- tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+- [ ] ✅ Test passes (green phase)
+
+**Estimated Effort:** 2-4 hours
+
+### Test: rejects revoked refresh tokens across subsequent refresh attempts
+
+**File:** `tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+
+**Tasks to make this test pass:**
+
+- [ ] Implement `POST /api/v1/platform/_kernel/sessions/refresh/revoke`.
+- [ ] Ensure revoked refresh credentials cannot be used for future rotation.
+- [ ] Return deterministic refusal envelope `REFRESH_TOKEN_REVOKED`.
+- [ ] Run test: `npm run test:e2e -- tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+- [ ] ✅ Test passes (green phase)
+
+**Estimated Effort:** 2-4 hours
+
+---
+
+## Running Tests
+
+```bash
+# Collect and run Story 0.3 RED-phase tests
+npm run test:e2e -- tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts
+
+# Headed e2e diagnostics
+npm run test:e2e:headed -- tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts
+
+# Debug story suite
+npm run test:e2e:debug -- tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts
+```
+
+---
+
+## Red-Green-Refactor Workflow
+
+### RED Phase (Complete) ✅
+
+- ✅ API and E2E acceptance tests generated for Story 0.3.
+- ✅ Tests encode expected behavior for session persistence + refresh security.
+- ✅ Tests are intentionally skipped to mark pre-implementation RED artifacts.
+- ✅ Support factory and fixture generated for deterministic payload/header setup.
+
+### GREEN Phase (DEV Team - Next Steps)
+
+1. Implement refresh issue/rotate/revoke platform kernel contracts.
+2. Persist hashed refresh metadata in `platform.sessions` with audit fields.
+3. Enforce deterministic replay/revoked token refusals.
+4. Add session-security UI states and data-testid attributes listed above.
+5. Remove `test.skip()` markers and run Story 0.3 suite until passing.
+
+### REFACTOR Phase (After GREEN)
+
+- Consolidate session-security request builders and refusal assertions in shared helpers.
+- Reduce duplication between API and E2E assertions while preserving deterministic refusal coverage.
+
+---
+
+## Step Progress
+
+- **Step 1:** Loaded story context, Playwright config, existing test patterns, TEA config flags (`tea_use_playwright_utils=true`, `tea_browser_automation=auto`), and required knowledge fragments.
+- **Step 2:** Selected mode = **AI generation** (ACs are explicit and kernel/session contracts are well-defined).
+- **Step 3:** Mapped AC coverage to **API-primary** with E2E security-journey parity and P0/P1 prioritization.
+- **Step 4:** Generated RED-phase API/E2E specs plus factory/fixture support.
+- **Step 4C:** Aggregated subprocess outputs, validated `test.skip()` compliance, created checklist + summary artifacts.
+- **Step 5:** Validated output completeness and test discoverability.
+
+---
+
+## Validation Evidence
+
+**Command:**
+
+`npm run test:e2e -- --list tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts`
+
+**Result:**
+
+- 7 tests discovered across 2 files.
+- All tests are RED-phase artifacts (`test.skip`) pending implementation.
+
+---
+
+## Output
+
+- Checklist: `/Users/jeremiahotis/moneyshyft/_bmad-output/test-artifacts/atdd-checklist-0-3.md`
+- API spec: `/Users/jeremiahotis/moneyshyft/tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts`
+- E2E spec: `/Users/jeremiahotis/moneyshyft/tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts`
+- Factory: `/Users/jeremiahotis/moneyshyft/tests/support/factories/sessionRotationFactory.ts`
+- Fixture: `/Users/jeremiahotis/moneyshyft/tests/support/fixtures/sessionRotation.fixture.ts`
+

--- a/_bmad/tea/workflows/testarch/atdd/steps-c/step-01-preflight-and-context.md
+++ b/_bmad/tea/workflows/testarch/atdd/steps-c/step-01-preflight-and-context.md
@@ -47,6 +47,21 @@ If any are missing: **HALT** and notify the user.
 
 ---
 
+## 1.5 Mandatory Git Policy Gate (Hard Requirement)
+
+Before any ATDD generation work:
+
+- Run `npm run policy:check`
+- Run `npm run branch:ensure-workflow -- --workflow _bmad/tea/workflows/testarch/atdd/workflow.yaml --story {story_file}`
+
+Rules:
+
+- If `{story_file}` is not resolved yet, resolve it first (or ask user explicitly).
+- If either command fails (non-zero exit), **HALT** and report the failure.
+- Do **not** proceed to Step 2 until both commands pass.
+
+---
+
 ## 2. Load Story Context
 
 - Read story markdown from `{story_file}` (or ask user if not provided)

--- a/tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts
+++ b/tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest } from '../../support/helpers/apiClient';
+import {
+  createRefreshIssuePayload,
+  createRefreshRevokePayload,
+  createRefreshRotatePayload,
+  createSessionHeaders,
+} from '../../support/factories/sessionRotationFactory';
+
+test.describe('Story 0.3 ATDD RED - platform session store and refresh rotation API coverage', () => {
+  test.skip('persists hashed refresh state with expiry and revocation metadata @P0', async ({ request }) => {
+    // Given a valid tenant-authenticated context and refresh issue payload
+    const headers = createSessionHeaders({ tenantId: 'tenant-session-alpha' });
+    const payload = createRefreshIssuePayload({
+      userId: 'user-session-alpha',
+      refreshTokenId: 'rt-session-alpha',
+    });
+
+    // When the platform kernel issues a refresh session record
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/sessions/refresh/issue',
+      headers,
+      data: payload,
+    });
+
+    // Then platform.sessions should persist hashed refresh metadata and audit fields
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: true,
+      session: {
+        tenantId: 'tenant-session-alpha',
+        userId: 'user-session-alpha',
+        refreshTokenHash: expect.any(String),
+        refreshTokenExpiresAt: expect.any(String),
+        revokedAt: null,
+      },
+    });
+    expect(body.session.refreshTokenHash).not.toContain('rt-session-alpha');
+  });
+
+  test.skip('rotates refresh sessions and revokes prior refresh state atomically @P0', async ({ request }) => {
+    // Given an existing refresh session context
+    const headers = createSessionHeaders({ tenantId: 'tenant-session-alpha' });
+    const payload = createRefreshRotatePayload({
+      sessionId: 'sess-rotation-alpha',
+      presentedRefreshToken: 'refresh-old-alpha',
+      replacementRefreshTokenId: 'refresh-new-alpha',
+    });
+
+    // When refresh rotation is requested
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/sessions/refresh/rotate',
+      headers,
+      data: payload,
+    });
+
+    // Then prior session token state is revoked and replacement metadata is persisted
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: true,
+      rotated: {
+        priorSessionId: 'sess-rotation-alpha',
+        priorRevokedAt: expect.any(String),
+        replacementSessionId: expect.any(String),
+        replacementRefreshTokenHash: expect.any(String),
+      },
+    });
+  });
+
+  test.skip('rejects replayed refresh token attempts deterministically @P1', async ({ request }) => {
+    // Given a replayed refresh token from an already-rotated session
+    const headers = createSessionHeaders({ tenantId: 'tenant-session-alpha' });
+    const payload = createRefreshRotatePayload({
+      sessionId: 'sess-replay-alpha',
+      presentedRefreshToken: 'refresh-replayed-alpha',
+    });
+
+    // When replayed refresh token is presented again
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/sessions/refresh/rotate',
+      headers,
+      data: payload,
+    });
+
+    // Then request is rejected with deterministic replay refusal semantics
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: false,
+      code: 'REFRESH_TOKEN_REPLAY_DETECTED',
+      refusalType: 'security',
+    });
+  });
+
+  test.skip('rejects revoked refresh tokens across subsequent refresh attempts @P1', async ({ request }) => {
+    // Given a refresh session has already been revoked
+    const headers = createSessionHeaders({ tenantId: 'tenant-session-alpha' });
+    const revokePayload = createRefreshRevokePayload({
+      sessionId: 'sess-revoked-alpha',
+      reason: 'replay-detected',
+    });
+
+    await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/sessions/refresh/revoke',
+      headers,
+      data: revokePayload,
+    });
+
+    const rotatePayload = createRefreshRotatePayload({
+      sessionId: 'sess-revoked-alpha',
+      presentedRefreshToken: 'refresh-revoked-alpha',
+    });
+
+    // When revoked refresh token is reused
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/sessions/refresh/rotate',
+      headers,
+      data: rotatePayload,
+    });
+
+    // Then platform kernel rejects token with revoked-token refusal code
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: false,
+      code: 'REFRESH_TOKEN_REVOKED',
+      refusalType: 'security',
+    });
+  });
+});

--- a/tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts
+++ b/tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Story 0.3 ATDD RED - platform session store and refresh rotation journey', () => {
+  test.skip('shows active refresh session metadata after authenticated entry @P0', async ({ page }) => {
+    // Given a user can authenticate into the first-party session flow
+    await page.goto('/login');
+    await page.getByTestId('auth-email-input').fill('security.engineer@example.com');
+    await page.getByTestId('auth-password-input').fill('SecurePass123!');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    // When the user opens session security settings
+    await page.getByRole('link', { name: 'Security' }).click();
+    await page.getByTestId('session-store-panel').waitFor({ state: 'visible' });
+
+    // Then refresh session metadata is visible and revocation marker is unset
+    await expect(page.getByTestId('refresh-token-hash')).toBeVisible();
+    await expect(page.getByTestId('refresh-token-expires-at')).toBeVisible();
+    await expect(page.getByTestId('refresh-token-revoked-at')).toHaveText('Active');
+  });
+
+  test.skip('rotates refresh token and replaces prior session card in security journey @P0', async ({ page }) => {
+    // Given a user is on security settings with an active session card
+    await page.goto('/settings/security');
+    await page.getByTestId('session-store-panel').waitFor({ state: 'visible' });
+
+    // When the user rotates refresh credentials
+    await page.getByRole('button', { name: 'Rotate refresh token' }).click();
+
+    // Then previous token is marked revoked and replacement token metadata is shown
+    await expect(page.getByTestId('session-rotation-toast')).toBeVisible();
+    await expect(page.getByTestId('previous-refresh-token-status')).toHaveText('Revoked');
+    await expect(page.getByTestId('active-refresh-token-status')).toHaveText('Active');
+  });
+
+  test.skip('blocks replayed or revoked refresh actions with deterministic refusal banner @P1', async ({ page }) => {
+    // Given the session panel has a replay/revoke simulation action for diagnostics
+    await page.goto('/settings/security');
+    await page.getByTestId('session-store-panel').waitFor({ state: 'visible' });
+
+    // When a replayed refresh attempt is triggered
+    await page.getByRole('button', { name: 'Replay revoked token' }).click();
+
+    // Then the refusal envelope is surfaced with deterministic security code
+    await expect(page.getByTestId('session-refusal-banner')).toBeVisible();
+    await expect(page.getByTestId('session-refusal-code')).toHaveText('REFRESH_TOKEN_REPLAY_DETECTED');
+  });
+});

--- a/tests/support/factories/sessionRotationFactory.ts
+++ b/tests/support/factories/sessionRotationFactory.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from 'node:crypto';
+
+type SessionHeaderOverrides = {
+  tenantId?: string;
+  correlationId?: string;
+  csrfToken?: string;
+  authToken?: string;
+};
+
+type RefreshIssuePayloadOverrides = {
+  userId?: string;
+  sessionFingerprint?: string;
+  refreshTokenId?: string;
+  expiresInSeconds?: number;
+};
+
+type RefreshRotatePayloadOverrides = {
+  sessionId?: string;
+  presentedRefreshToken?: string;
+  replacementRefreshTokenId?: string;
+};
+
+type RefreshRevokePayloadOverrides = {
+  sessionId?: string;
+  reason?: 'logout' | 'rotation' | 'replay-detected' | 'admin-revoke';
+};
+
+export function createSessionHeaders(overrides: SessionHeaderOverrides = {}): Record<string, string> {
+  const tenantId = overrides.tenantId ?? `tenant-${randomUUID()}`;
+  const correlationId = overrides.correlationId ?? `corr-${randomUUID()}`;
+  const csrfToken = overrides.csrfToken ?? `csrf-${randomUUID()}`;
+  const authToken = overrides.authToken ?? `access-${randomUUID()}`;
+
+  return {
+    'x-tenant-id': tenantId,
+    'x-correlation-id': correlationId,
+    'x-csrf-token': csrfToken,
+    authorization: `Bearer ${authToken}`,
+  };
+}
+
+export function createRefreshIssuePayload(
+  overrides: RefreshIssuePayloadOverrides = {},
+): Record<string, string | number> {
+  return {
+    userId: overrides.userId ?? `user-${randomUUID()}`,
+    sessionFingerprint: overrides.sessionFingerprint ?? `fp-${randomUUID()}`,
+    refreshTokenId: overrides.refreshTokenId ?? `rt-${randomUUID()}`,
+    expiresInSeconds: overrides.expiresInSeconds ?? 60 * 60 * 24 * 30,
+  };
+}
+
+export function createRefreshRotatePayload(
+  overrides: RefreshRotatePayloadOverrides = {},
+): Record<string, string> {
+  return {
+    sessionId: overrides.sessionId ?? `sess-${randomUUID()}`,
+    presentedRefreshToken: overrides.presentedRefreshToken ?? `refresh-${randomUUID()}`,
+    replacementRefreshTokenId: overrides.replacementRefreshTokenId ?? `rt-next-${randomUUID()}`,
+  };
+}
+
+export function createRefreshRevokePayload(
+  overrides: RefreshRevokePayloadOverrides = {},
+): Record<string, string> {
+  return {
+    sessionId: overrides.sessionId ?? `sess-${randomUUID()}`,
+    reason: overrides.reason ?? 'replay-detected',
+  };
+}

--- a/tests/support/fixtures/sessionRotation.fixture.ts
+++ b/tests/support/fixtures/sessionRotation.fixture.ts
@@ -1,0 +1,31 @@
+import { test as base } from '@playwright/test';
+import {
+  createRefreshIssuePayload,
+  createRefreshRevokePayload,
+  createRefreshRotatePayload,
+  createSessionHeaders,
+} from '../factories/sessionRotationFactory';
+
+type SessionRotationFixtures = {
+  sessionHeaders: ReturnType<typeof createSessionHeaders>;
+  refreshIssuePayload: ReturnType<typeof createRefreshIssuePayload>;
+  refreshRotatePayload: ReturnType<typeof createRefreshRotatePayload>;
+  refreshRevokePayload: ReturnType<typeof createRefreshRevokePayload>;
+};
+
+export const test = base.extend<SessionRotationFixtures>({
+  sessionHeaders: async ({}, use) => {
+    await use(createSessionHeaders());
+  },
+  refreshIssuePayload: async ({}, use) => {
+    await use(createRefreshIssuePayload());
+  },
+  refreshRotatePayload: async ({}, use) => {
+    await use(createRefreshRotatePayload());
+  },
+  refreshRevokePayload: async ({}, use) => {
+    await use(createRefreshRevokePayload());
+  },
+});
+
+export { expect } from '@playwright/test';


### PR DESCRIPTION
## Summary
- add Story 0.3 ATDD RED-phase API and E2E specs for platform session store + refresh rotation
- add session rotation factory and fixture scaffolding for deterministic test data/setup
- generate Story 0.3 ATDD checklist artifact
- enforce ATDD preflight git policy gate (`policy:check` + `branch:ensure-workflow`)

## Validation
- `npm run test:e2e -- --list tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts`
- `npm run test:e2e -- tests/api/platform/platform-session-store-and-refresh-rotation.api.spec.ts tests/e2e/platform/platform-session-store-and-refresh-rotation.spec.ts`

## Notes
- tests are intentionally `test.skip()` as RED-phase ATDD artifacts
