### PR TITLE
Fix: resolve story 0.5 review findings and sync story/git state

### DIFF
--- a/_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md
+++ b/_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md
@@ -1,6 +1,6 @@
 # Story 0.5: Shared API Envelope and Business Refusal Contract
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -17,10 +17,10 @@ so that [benefit].
 
 ## Tasks / Subtasks
 
-- [ ] Implement acceptance criterion 1 (AC: 1)
-  - [ ] Add automated coverage for AC 1
-- [ ] Implement acceptance criterion 2 (AC: 2)
-  - [ ] Add automated coverage for AC 2
+- [x] Implement acceptance criterion 1 (AC: 1)
+  - [x] Add automated coverage for AC 1
+- [x] Implement acceptance criterion 2 (AC: 2)
+  - [x] Add automated coverage for AC 2
 
 ## Dev Notes
 
@@ -49,12 +49,25 @@ GPT-5 Codex
 
 ### Debug Log References
 
--
+- `cd src && npm test -- --runInBand src/__tests__/apiEnvelopeContract.test.ts` (RED/GREEN cycle for AC1 and AC2)
+- `cd src && npm test -- --runInBand` (full regression suite)
 
 ### Completion Notes List
 
--
+- Added shared success envelope helper in `src/src/platform/envelopes/response.ts` and wired it through `POST /api/v1/platform/_kernel/contracts/envelope/success`.
+- Added AC1 contract coverage in `src/src/__tests__/apiEnvelopeContract.test.ts`.
+- Updated shared route registry and middleware-chain registration test expectations for `/api/v1/platform`.
+- Added shared `refusal(...)` envelope helper with fixed business contract semantics (`HTTP 200`, `ok=false`, `code`, `message`, `refusalType`).
+- Added `POST /api/v1/platform/_kernel/contracts/envelope/business-refusal` contract route and AC2 coverage.
 
 ### File List
 
--
+- src/src/platform/envelopes/response.ts
+- src/src/routes/api/v1/platform-contracts.ts
+- src/src/api/registerRoutes.ts
+- src/src/__tests__/apiEnvelopeContract.test.ts
+- src/src/__tests__/app-entrypoint-kernel.test.ts
+
+## Change Log
+
+- 2026-02-17: Implemented Story 0.5 shared success/refusal envelope helpers and contract endpoints with automated test coverage.

--- a/_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md
+++ b/_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md
@@ -1,6 +1,6 @@
 # Story 0.5: Shared API Envelope and Business Refusal Contract
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -59,15 +59,43 @@ GPT-5 Codex
 - Updated shared route registry and middleware-chain registration test expectations for `/api/v1/platform`.
 - Added shared `refusal(...)` envelope helper with fixed business contract semantics (`HTTP 200`, `ok=false`, `code`, `message`, `refusalType`).
 - Added `POST /api/v1/platform/_kernel/contracts/envelope/business-refusal` contract route and AC2 coverage.
+- Added shared `systemError(...)` helper and contract endpoint `POST /api/v1/platform/_kernel/contracts/envelope/system-error`.
+- Added API response normalization in `responseEnvelope` middleware so `/api/*` platform and module endpoints serialize through shared envelope builders.
+- Added module route contract coverage (`/api/v1/auth/logout` success, `/api/v1/auth/refresh` refusal) in `apiEnvelopeContract` tests.
+- Reconciled story documentation with implementation commit history and current changes.
 
 ### File List
 
+- src/jest.config.js
 - src/src/platform/envelopes/response.ts
+- src/src/platform/middleware/responseEnvelope.ts
 - src/src/routes/api/v1/platform-contracts.ts
 - src/src/api/registerRoutes.ts
 - src/src/__tests__/apiEnvelopeContract.test.ts
 - src/src/__tests__/app-entrypoint-kernel.test.ts
+- _bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+
+## Senior Developer Review (AI)
+
+### Reviewer
+
+- Jeremiah (AI-assisted review)
+
+### Findings
+
+- Resolved prior review findings:
+  - AC1 now enforced for `/api/*` endpoints through shared envelope serialization.
+  - Shared `systemError` helper now implemented and contract-tested.
+  - Test suite now includes module endpoint serialization coverage.
+  - Story File List now includes missing implementation file (`src/jest.config.js`) and current envelope middleware changes.
+- AC1 and AC2 are implemented and covered by executable tests:
+  - `src/src/__tests__/apiEnvelopeContract.test.ts`
+  - `src/src/__tests__/app-entrypoint-kernel.test.ts`
+- Story File List has been reconciled against story implementation commits and current git changes.
 
 ## Change Log
 
 - 2026-02-17: Implemented Story 0.5 shared success/refusal envelope helpers and contract endpoints with automated test coverage.
+- 2026-02-17: Senior developer review completed; no blocking issues found. Story moved to `done` and sprint tracking synced.
+- 2026-02-17: Addressed review findings by adding `systemError`, API-wide envelope serialization for `/api/*`, expanded module route contract tests, and reconciled story/git documentation.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -45,7 +45,7 @@ development_status:
   0-2-tenancy-context-resolution-and-repository-enforcement: review
   0-3-platform-session-store-and-refresh-rotation: review
   0-4-csrf-and-parent-domain-cookie-enforcement: done
-  0-5-shared-api-envelope-and-business-refusal-contract: ready-for-dev
+  0-5-shared-api-envelope-and-business-refusal-contract: review
   0-6-platform-events-and-outbox-schema-foundations: ready-for-dev
   0-7-mutation-transaction-wrapper-with-mandatory-event-outbox-writes: ready-for-dev
   0-8-centralized-time-service-and-utc-local-rendering-contract: ready-for-dev

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -45,7 +45,7 @@ development_status:
   0-2-tenancy-context-resolution-and-repository-enforcement: review
   0-3-platform-session-store-and-refresh-rotation: review
   0-4-csrf-and-parent-domain-cookie-enforcement: done
-  0-5-shared-api-envelope-and-business-refusal-contract: review
+  0-5-shared-api-envelope-and-business-refusal-contract: done
   0-6-platform-events-and-outbox-schema-foundations: ready-for-dev
   0-7-mutation-transaction-wrapper-with-mandatory-event-outbox-writes: ready-for-dev
   0-8-centralized-time-service-and-utc-local-rendering-contract: ready-for-dev

--- a/_bmad-output/test-artifacts/atdd-checklist-0-5.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-0-5.md
@@ -1,0 +1,306 @@
+---
+stepsCompleted:
+  - step-01-preflight-and-context
+  - step-02-generation-mode
+  - step-03-test-strategy
+  - step-04c-aggregate
+  - step-05-validate-and-complete
+lastStep: step-05-validate-and-complete
+lastSaved: '2026-02-17T18:22:57Z'
+storyId: '0-5'
+storyFile: '/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md'
+generationMode: 'ai-generation'
+tddPhase: 'RED'
+subprocessTimestamp: '2026-02-17T18-22-57Z'
+---
+
+# ATDD Checklist - Epic 0, Story 5: Shared API Envelope and Business Refusal Contract
+
+**Date:** 2026-02-17
+**Author:** Jeremiah
+**Primary Test Level:** API
+
+---
+
+## Workflow Progress Log
+
+### Step 1 - Preflight and Context
+
+- Story loaded: `/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md`
+- Framework config loaded: `/Users/jeremiahotis/moneyshyft/playwright.config.ts`
+- Test patterns reviewed under `/Users/jeremiahotis/moneyshyft/tests`
+- Required policy gates passed on branch: `codex/story-0-5-shared-api-envelope-and-business-refusal-contract`
+  - `npm run policy:check`
+  - `npm run branch:ensure-workflow -- --workflow _bmad/tea/workflows/testarch/atdd/workflow.yaml --story _bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md`
+- TEA flags:
+  - `tea_use_playwright_utils: true`
+  - `tea_browser_automation: auto`
+
+Knowledge fragments loaded:
+- Core: `data-factories`, `component-tdd`, `test-quality`, `test-healing-patterns`, `selector-resilience`, `timing-debugging`
+- Playwright Utils: `overview`, `api-request`, `network-recorder`, `auth-session`, `intercept-network-call`, `recurse`, `log`, `file-utils`, `network-error-monitor`, `fixtures-composition`
+- Browser automation: `playwright-cli`
+
+### Step 2 - Generation Mode
+
+Selected mode: **AI generation**
+
+Reasoning:
+- Acceptance criteria are concise and contract-driven, suitable for deterministic ATDD generation.
+- Existing platform contract tests under `tests/api/platform` and `tests/e2e/platform` provide consistent naming and assertion patterns.
+- Recording mode was not required because this story is backend contract focused and tests are intentionally RED-phase.
+
+### Step 3 - Test Strategy
+
+Acceptance criteria mapped to scenarios:
+
+1. Shared envelope helpers are reused for success and refusal response contracts.
+2. Business refusals preserve HTTP 200 while returning `ok=false` with structured `code`/`message`.
+3. Envelope shape remains consistent across success/refusal paths for downstream consumers.
+4. Correlation and tenant metadata remain stable across contract paths.
+
+Test levels selected:
+- API (P0/P1): envelope contract correctness and business refusal semantics
+- E2E (P0/P1): request-journey consistency for contract consumers
+
+Priority allocation:
+- P0: shared envelope success contract + business refusal HTTP 200 contract
+- P1: envelope shape consistency, deterministic refusal payloads, correlation continuity
+
+RED-phase enforcement:
+- All generated tests use `test.skip(...)` intentionally
+- Assertions target expected final contract behavior (not placeholder assertions)
+
+---
+
+## Story Summary
+
+Story 0.5 defines a shared platform response-envelope contract and business refusal semantics for kernel APIs. The RED-phase tests lock the external behavior before implementation so success and refusal paths remain consistent, deterministic, and safe for downstream consumers.
+
+**As a** platform integrator  
+**I want** shared envelope helpers and deterministic business refusal contracts  
+**So that** API consumers can rely on stable response semantics
+
+---
+
+## Acceptance Criteria
+
+1. they use shared envelope helpers
+2. business refusals return HTTP 200 with `ok=false` and structured code/message
+
+---
+
+## Failing Tests Created (RED Phase)
+
+### API Tests (4 tests)
+
+**File:** `tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts` (149 lines)
+
+- ✅ **Test:** `returns canonical success envelope using shared helper contract @P0`
+  - **Status:** RED - expected failure until shared helper-backed success contract endpoint exists
+  - **Verifies:** canonical success envelope keys and metadata contract
+- ✅ **Test:** `returns business refusal contract as HTTP 200 with structured code/message @P0`
+  - **Status:** RED - expected failure until business refusal contract endpoint is implemented
+  - **Verifies:** HTTP 200 + `ok=false` + structured `code`/`message` + `refusalType=business`
+- ✅ **Test:** `keeps shared envelope shape consistent between success and business refusal contracts @P1`
+  - **Status:** RED - expected failure until shared helper contract is reused consistently
+  - **Verifies:** canonical top-level envelope shape across both outcomes
+- ✅ **Test:** `keeps refusal envelopes deterministic and free of internal stack leakage @P1`
+  - **Status:** RED - expected failure until refusal serialization and hardening are implemented
+  - **Verifies:** deterministic refusal payload and no internal `stack` leakage
+
+### E2E Tests (3 tests)
+
+**File:** `tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts` (86 lines)
+
+- ✅ **Test:** `keeps HTTP 200 semantics for business refusals in journey flow @P0`
+  - **Status:** RED - expected failure until contract path is implemented
+  - **Verifies:** journey-level refusal uses HTTP 200 with business refusal envelope
+- ✅ **Test:** `echoes correlation id consistently across success and refusal envelope paths @P1`
+  - **Status:** RED - expected failure until shared helper wiring is complete
+  - **Verifies:** correlation continuity across success and refusal responses
+- ✅ **Test:** `exposes structured refusal fields for downstream UI adapters @P1`
+  - **Status:** RED - expected failure until final refusal contract shape is implemented
+  - **Verifies:** downstream adapters can rely on deterministic `ok/code/message/refusalType`
+
+### Component Tests (0 tests)
+
+No component-level tests were generated for this story because scope is API contract behavior.
+
+---
+
+## Data Factories Created
+
+### Shared API Envelope Factory
+
+**File:** `tests/support/factories/sharedApiEnvelopeFactory.ts`
+
+**Exports:**
+
+- `createSharedEnvelopeHeaders(overrides?)`
+- `createSharedEnvelopeSuccessProbe(overrides?)`
+- `createBusinessRefusalProbe(overrides?)`
+
+Factory outputs provide deterministic headers and contract probe payloads for RED-phase API/E2E tests.
+
+---
+
+## Fixtures Created
+
+### Shared API Envelope Fixture
+
+**File:** `tests/support/fixtures/sharedApiEnvelope.fixture.ts`
+
+**Fixtures:**
+
+- `sharedEnvelopeHeaders`
+- `sharedSuccessProbe`
+- `businessRefusalProbe`
+
+These fixtures provide isolated, reusable contract inputs for journey-level tests.
+
+---
+
+## Mock Requirements
+
+External mocks are not required for this story.
+
+Expected kernel contract endpoints (to implement):
+- `POST /api/v1/platform/_kernel/contracts/envelope/success`
+- `POST /api/v1/platform/_kernel/contracts/envelope/business-refusal`
+
+---
+
+## Required data-testid Attributes
+
+No UI selectors are required for this story in ATDD RED phase.
+
+---
+
+## Implementation Checklist
+
+### Test: Shared envelope success contract
+
+**File:** `tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts`
+
+**Tasks to make this test set pass:**
+
+- [ ] Implement shared envelope helper(s) for canonical success contract responses
+- [ ] Implement success contract endpoint and return expected `code`/`message`
+- [ ] Ensure `correlationId` and `tenantId` are included in envelope
+- [ ] Remove `test.skip()` from success contract test
+- [ ] Run: `npm run test:e2e -- tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts`
+- [ ] ✅ Tests pass
+
+### Test: Business refusal contract semantics
+
+**File:** `tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts`
+
+**Tasks to make this test set pass:**
+
+- [ ] Implement business refusal helper path returning HTTP 200 + `ok=false`
+- [ ] Emit deterministic refusal fields: `code`, `message`, `refusalType='business'`
+- [ ] Reuse shared envelope helper shape between success and refusal outcomes
+- [ ] Remove `test.skip()` from business refusal API tests
+- [ ] Run: `npm run test:e2e -- tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts`
+- [ ] ✅ Tests pass
+
+### Test: Journey-level contract stability
+
+**File:** `tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts`
+
+**Tasks to make this test set pass:**
+
+- [ ] Ensure journey callers receive HTTP 200 for business refusals
+- [ ] Preserve correlation metadata consistently across contract paths
+- [ ] Ensure refusal payload remains deterministic and adapter-safe
+- [ ] Remove `test.skip()` from E2E journey tests
+- [ ] Run: `npm run test:e2e -- tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts`
+- [ ] ✅ Tests pass
+
+---
+
+## Running Tests
+
+```bash
+# Run story 0.5 generated ATDD specs
+npm run test:e2e -- tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts
+
+# Run API spec only
+npm run test:e2e -- tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts
+
+# Run E2E spec only
+npm run test:e2e -- tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts
+
+# Run headed mode
+npm run test:e2e:headed -- tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts
+```
+
+---
+
+## Red-Green-Refactor Workflow
+
+### RED Phase (Complete) ✅
+
+- RED-phase ATDD contracts generated for API and journey levels.
+- Tests are intentionally `test.skip()` while implementation is missing.
+- Assertions are concrete and deterministic.
+
+### GREEN Phase (Next)
+
+1. Implement shared envelope helper and business refusal contract endpoints.
+2. Remove `test.skip()` incrementally (P0 first).
+3. Verify API tests green, then journey tests green.
+
+### REFACTOR Phase (After Green)
+
+1. Consolidate envelope serialization helpers into reusable platform contract utilities.
+2. Keep refusal envelope structure stable and versioned.
+3. Preserve deterministic response semantics and remove duplication.
+
+---
+
+## Test Execution Evidence
+
+Generation artifacts:
+
+- `/tmp/tea-atdd-api-tests-2026-02-17T18-22-57Z.json`
+- `/tmp/tea-atdd-e2e-tests-2026-02-17T18-22-57Z.json`
+- `/tmp/tea-atdd-summary-2026-02-17T18-22-57Z.json`
+
+Persisted copies:
+
+- `/Users/jeremiahotis/moneyshyft/_bmad-output/test-artifacts/atdd-temp/tea-atdd-api-tests-2026-02-17T18-22-57Z.json`
+- `/Users/jeremiahotis/moneyshyft/_bmad-output/test-artifacts/atdd-temp/tea-atdd-e2e-tests-2026-02-17T18-22-57Z.json`
+- `/Users/jeremiahotis/moneyshyft/_bmad-output/test-artifacts/atdd-temp/tea-atdd-summary-2026-02-17T18-22-57Z.json`
+
+Validation run:
+
+- `npm run test:e2e -- tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts`
+- Result: 7 skipped (expected in RED phase)
+
+---
+
+## Validation (Step 5)
+
+Checklist status:
+
+- [x] Prerequisites satisfied (story + framework + policy gates)
+- [x] Test files created and organized by level (API/E2E)
+- [x] All generated tests are explicitly RED-phase (`test.skip`)
+- [x] Acceptance criteria mapped to scenarios and priorities
+- [x] Supporting factory + fixture scaffolding created
+- [x] ATDD checklist output generated at required path
+- [x] Temp artifacts persisted under `{test_artifacts}/atdd-temp`
+
+Open assumptions/risks:
+
+- Story acceptance criteria are intentionally high-level; endpoint paths and refusal code names are contractual assumptions for RED-phase design.
+- Shared helper implementation boundaries (middleware helper vs service helper) should be confirmed during GREEN phase.
+
+---
+
+## Next Recommended Workflow
+
+- Continue with implementation workflow for Story 0.5.
+- After implementation, remove `test.skip()` and run green-phase verification.

--- a/_bmad-output/test-artifacts/atdd-temp/tea-atdd-api-tests-2026-02-17T18-22-57Z.json
+++ b/_bmad-output/test-artifacts/atdd-temp/tea-atdd-api-tests-2026-02-17T18-22-57Z.json
@@ -1,0 +1,36 @@
+{
+  "success": true,
+  "subprocess": "atdd-api-tests",
+  "tests": [
+    {
+      "file": "tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts",
+      "content": "import { test, expect } from '@playwright/test';\nimport { apiRequest } from '../../support/helpers/apiClient';\nimport {\n  createBusinessRefusalProbe,\n  createSharedEnvelopeHeaders,\n  createSharedEnvelopeSuccessProbe,\n} from '../../support/factories/sharedApiEnvelopeFactory';\n\ntest.describe('Story 0.5 atdd - shared API envelope and business refusal contract API coverage', () => {\n  test.skip('returns canonical success envelope using shared helper contract @P0', async ({ request }) => {\n    // Given a valid platform request context and success probe payload\n    const headers = createSharedEnvelopeHeaders({\n      tenantId: 'tenant-envelope-alpha',\n      correlationId: 'corr-envelope-alpha',\n    });\n    const successProbe = createSharedEnvelopeSuccessProbe();\n\n    // When the shared success envelope contract endpoint is called\n    const response = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/success',\n      headers,\n      data: successProbe.payload,\n    });\n\n    // Then a structured shared success envelope contract is returned\n    expect(response.status()).toBe(200);\n    const body = await response.json();\n    expect(body).toMatchObject({\n      ok: true,\n      code: successProbe.expected.code,\n      message: successProbe.expected.message,\n      correlationId: headers['x-correlation-id'],\n      tenantId: headers['x-tenant-id'],\n    });\n  });\n\n  test.skip('returns business refusal contract as HTTP 200 with structured code/message @P0', async ({ request }) => {\n    // Given a request that should violate a business envelope rule\n    const headers = createSharedEnvelopeHeaders({\n      tenantId: 'tenant-envelope-alpha',\n      correlationId: 'corr-envelope-refusal-alpha',\n    });\n    const refusalProbe = createBusinessRefusalProbe();\n\n    // When the business refusal contract endpoint is called\n    const response = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',\n      headers,\n      data: refusalProbe.payload,\n    });\n\n    // Then HTTP 200 is preserved with structured refusal semantics\n    expect(response.status()).toBe(200);\n    const body = await response.json();\n    expect(body).toMatchObject({\n      ok: false,\n      code: refusalProbe.expected.code,\n      message: refusalProbe.expected.message,\n      refusalType: refusalProbe.expected.refusalType,\n      correlationId: headers['x-correlation-id'],\n      tenantId: headers['x-tenant-id'],\n    });\n  });\n\n  test.skip('keeps shared envelope shape consistent between success and business refusal contracts @P1', async ({ request }) => {\n    // Given one request context reused across success and refusal probes\n    const headers = createSharedEnvelopeHeaders({\n      tenantId: 'tenant-envelope-consistency',\n      correlationId: 'corr-envelope-consistency',\n    });\n    const successProbe = createSharedEnvelopeSuccessProbe();\n    const refusalProbe = createBusinessRefusalProbe();\n\n    // When both contract endpoints are called\n    const successResponse = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/success',\n      headers,\n      data: successProbe.payload,\n    });\n    const refusalResponse = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',\n      headers,\n      data: refusalProbe.payload,\n    });\n\n    // Then they both emit the canonical top-level envelope contract keys\n    expect(successResponse.status()).toBe(200);\n    expect(refusalResponse.status()).toBe(200);\n\n    const successBody = await successResponse.json();\n    const refusalBody = await refusalResponse.json();\n    const requiredKeys = ['ok', 'code', 'message', 'correlationId', 'tenantId'];\n\n    expect(requiredKeys.every((key) => Object.prototype.hasOwnProperty.call(successBody, key))).toBe(true);\n    expect(requiredKeys.every((key) => Object.prototype.hasOwnProperty.call(refusalBody, key))).toBe(true);\n  });\n\n  test.skip('keeps refusal envelopes deterministic and free of internal stack leakage @P1', async ({ request }) => {\n    // Given a deterministic refusal probe payload\n    const headers = createSharedEnvelopeHeaders({\n      tenantId: 'tenant-envelope-hardening',\n      correlationId: 'corr-envelope-hardening',\n    });\n    const refusalProbe = createBusinessRefusalProbe({\n      code: 'ENVELOPE_BUSINESS_REFUSAL',\n      message: 'Requested amount exceeds available envelope balance',\n    });\n\n    // When the refusal contract endpoint is called repeatedly with same input\n    const firstResponse = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',\n      headers,\n      data: refusalProbe.payload,\n    });\n    const secondResponse = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',\n      headers,\n      data: refusalProbe.payload,\n    });\n\n    // Then structured refusal fields remain stable and implementation details are hidden\n    expect(firstResponse.status()).toBe(200);\n    expect(secondResponse.status()).toBe(200);\n\n    const firstBody = await firstResponse.json();\n    const secondBody = await secondResponse.json();\n\n    expect(firstBody).toMatchObject({\n      ok: false,\n      code: refusalProbe.expected.code,\n      message: refusalProbe.expected.message,\n      refusalType: 'business',\n    });\n    expect(secondBody).toMatchObject({\n      ok: false,\n      code: refusalProbe.expected.code,\n      message: refusalProbe.expected.message,\n      refusalType: 'business',\n    });\n    expect(firstBody).not.toHaveProperty('stack');\n    expect(secondBody).not.toHaveProperty('stack');\n  });\n});\n",
+      "description": "ATDD API tests for shared envelope and business refusal contract (RED PHASE)",
+      "expected_to_fail": true,
+      "acceptance_criteria_covered": [
+        "Shared API envelope helpers are used for structured contract responses",
+        "Business refusals return HTTP 200 with ok=false and structured code/message"
+      ],
+      "priority_coverage": {
+        "P0": 2,
+        "P1": 2,
+        "P2": 0,
+        "P3": 0
+      }
+    }
+  ],
+  "fixture_needs": [
+    "sharedApiEnvelopeFactory",
+    "sharedApiEnvelopeFixture"
+  ],
+  "knowledge_fragments_used": [
+    "api-request",
+    "data-factories",
+    "test-quality",
+    "test-levels",
+    "test-priorities"
+  ],
+  "test_count": 4,
+  "tdd_phase": "RED",
+  "summary": "Generated 4 FAILING API tests for Story 0.5 shared envelope/business refusal contract"
+}

--- a/_bmad-output/test-artifacts/atdd-temp/tea-atdd-e2e-tests-2026-02-17T18-22-57Z.json
+++ b/_bmad-output/test-artifacts/atdd-temp/tea-atdd-e2e-tests-2026-02-17T18-22-57Z.json
@@ -1,0 +1,34 @@
+{
+  "success": true,
+  "subprocess": "atdd-e2e-tests",
+  "tests": [
+    {
+      "file": "tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts",
+      "content": "import { apiRequest } from '../../support/helpers/apiClient';\nimport { test, expect } from '../../support/fixtures/sharedApiEnvelope.fixture';\n\ntest.describe('Story 0.5 atdd - shared API envelope and business refusal contract journey', () => {\n  test.skip('keeps HTTP 200 semantics for business refusals in journey flow @P0', async ({\n    request,\n    sharedEnvelopeHeaders,\n    businessRefusalProbe,\n  }) => {\n    // Given a browser-driven journey that triggers a business refusal contract path\n    const response = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',\n      headers: sharedEnvelopeHeaders,\n      data: businessRefusalProbe.payload,\n    });\n\n    // Then refusal is represented as a business contract (HTTP 200 + ok=false)\n    expect(response.status()).toBe(200);\n    const body = await response.json();\n    expect(body).toMatchObject({\n      ok: false,\n      code: businessRefusalProbe.expected.code,\n      message: businessRefusalProbe.expected.message,\n      refusalType: businessRefusalProbe.expected.refusalType,\n    });\n  });\n\n  test.skip('echoes correlation id consistently across success and refusal envelope paths @P1', async ({\n    request,\n    sharedEnvelopeHeaders,\n    sharedSuccessProbe,\n    businessRefusalProbe,\n  }) => {\n    // Given one request correlation context across multiple contract paths\n    const successResponse = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/success',\n      headers: sharedEnvelopeHeaders,\n      data: sharedSuccessProbe.payload,\n    });\n    const refusalResponse = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',\n      headers: sharedEnvelopeHeaders,\n      data: businessRefusalProbe.payload,\n    });\n\n    // Then both responses should preserve the same correlation id\n    expect(successResponse.status()).toBe(200);\n    expect(refusalResponse.status()).toBe(200);\n\n    const successBody = await successResponse.json();\n    const refusalBody = await refusalResponse.json();\n\n    expect(successBody.correlationId).toBe(sharedEnvelopeHeaders['x-correlation-id']);\n    expect(refusalBody.correlationId).toBe(sharedEnvelopeHeaders['x-correlation-id']);\n  });\n\n  test.skip('exposes structured refusal fields for downstream UI adapters @P1', async ({\n    request,\n    sharedEnvelopeHeaders,\n    businessRefusalProbe,\n  }) => {\n    // Given a refusal scenario used by downstream UI adapters\n    const response = await apiRequest(request, {\n      method: 'POST',\n      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',\n      headers: sharedEnvelopeHeaders,\n      data: businessRefusalProbe.payload,\n    });\n\n    // Then response contains deterministic contract fields for rendering and localization\n    expect(response.status()).toBe(200);\n    const body = await response.json();\n\n    expect(body).toMatchObject({\n      ok: false,\n      code: businessRefusalProbe.expected.code,\n      message: businessRefusalProbe.expected.message,\n      refusalType: businessRefusalProbe.expected.refusalType,\n    });\n    expect(typeof body.message).toBe('string');\n    expect(body.message.length).toBeGreaterThan(0);\n  });\n});\n",
+      "description": "ATDD E2E tests for shared envelope and business refusal contract journey (RED PHASE)",
+      "expected_to_fail": true,
+      "acceptance_criteria_covered": [
+        "Shared API envelope helpers are used for structured contract responses",
+        "Business refusals return HTTP 200 with ok=false and structured code/message"
+      ],
+      "priority_coverage": {
+        "P0": 1,
+        "P1": 2,
+        "P2": 0,
+        "P3": 0
+      }
+    }
+  ],
+  "fixture_needs": [
+    "sharedApiEnvelopeFixture"
+  ],
+  "knowledge_fragments_used": [
+    "selector-resilience",
+    "timing-debugging",
+    "test-quality",
+    "playwright-cli"
+  ],
+  "test_count": 3,
+  "tdd_phase": "RED",
+  "summary": "Generated 3 FAILING E2E tests for Story 0.5 shared envelope/business refusal journey"
+}

--- a/_bmad-output/test-artifacts/atdd-temp/tea-atdd-summary-2026-02-17T18-22-57Z.json
+++ b/_bmad-output/test-artifacts/atdd-temp/tea-atdd-summary-2026-02-17T18-22-57Z.json
@@ -1,0 +1,36 @@
+{
+  "tdd_phase": "RED",
+  "total_tests": 7,
+  "api_tests": 4,
+  "e2e_tests": 3,
+  "all_tests_skipped": true,
+  "expected_to_fail": true,
+  "fixtures_created": 2,
+  "acceptance_criteria_covered": [
+    "Shared API envelope helpers are used for structured contract responses",
+    "Business refusals return HTTP 200 with ok=false and structured code/message"
+  ],
+  "knowledge_fragments_used": [
+    "data-factories",
+    "component-tdd",
+    "test-quality",
+    "test-healing-patterns",
+    "selector-resilience",
+    "timing-debugging",
+    "overview",
+    "api-request",
+    "network-recorder",
+    "auth-session",
+    "intercept-network-call",
+    "recurse",
+    "log",
+    "file-utils",
+    "network-error-monitor",
+    "fixtures-composition",
+    "playwright-cli",
+    "test-levels",
+    "test-priorities"
+  ],
+  "subprocess_execution": "PARALLEL (API + E2E)",
+  "performance_gain": "~50% faster than sequential"
+}

--- a/_bmad-output/test-artifacts/automation-summary.md
+++ b/_bmad-output/test-artifacts/automation-summary.md
@@ -1,113 +1,86 @@
 ---
-stepsCompleted: ['step-01-preflight-and-context','step-02-identify-targets','step-03-generate-tests','step-03c-aggregate','step-04-validate-and-summarize']
-lastStep: 'step-04-validate-and-summarize'
-lastSaved: '2026-02-17T11:40:00Z'
+stepsCompleted:
+  - step-01-preflight-and-context
+  - step-02-identify-targets
+  - step-03-generate-tests
+  - step-03c-aggregate
+  - step-04-validate-and-summarize
+lastStep: step-04-validate-and-summarize
+lastSaved: 2026-02-17T19:52:18Z
 ---
 
-# Automation Summary - Story 0.4
-
-## Scope
-
-Expanded test automation coverage for:
-- `/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-4-csrf-and-parent-domain-cookie-enforcement.md`
-
-Primary focus: CSRF rejection semantics for state-changing routes and parent-domain cookie-policy enforcement for `app.*` / `api.*` topology.
+# Test Automation Summary - Story 0.5
 
 ## Step 1 - Preflight and Context
-
-- Mode: `BMad-Integrated` (story artifact provided).
-- Framework readiness confirmed:
-  - `/Users/jeremiahotis/moneyshyft/playwright.config.ts`
-  - `/Users/jeremiahotis/moneyshyft/package.json`
-  - `/Users/jeremiahotis/moneyshyft/tests/`
-- Config flags loaded:
-  - `tea_use_playwright_utils: true`
-  - `tea_browser_automation: auto`
-- Existing 0.4 scaffolding discovered (ATDD-style skipped tests):
-  - `/Users/jeremiahotis/moneyshyft/tests/api/platform/csrf-and-parent-domain-cookie-enforcement.api.spec.ts`
-  - `/Users/jeremiahotis/moneyshyft/tests/e2e/platform/csrf-and-parent-domain-cookie-enforcement.spec.ts`
-
-Knowledge fragments loaded for this run:
-- Core: `test-levels-framework`, `test-priorities`, `data-factories`, `selective-testing`, `ci-burn-in`, `test-quality`
-- API/E2E generation: `api-testing-patterns`, `fixture-architecture`, `network-first`, `selector-resilience`
-- Playwright Utils and tooling: `overview`, `api-request`, `auth-session`, `intercept-network-call`, `recurse`, `log`, `file-utils`, `burn-in`, `network-error-monitor`, `fixtures-composition`, `playwright-cli`
+- Mode: BMad-Integrated
+- Input artifact: `_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md`
+- Framework readiness: `playwright.config.ts` present and `@playwright/test` installed in `package.json`
+- Existing test structure detected under `tests/` with `api`, `e2e`, `support/fixtures`, and `support/factories`
+- TEA flags loaded from `_bmad/tea/config.yaml`:
+  - `tea_use_playwright_utils=true`
+  - `tea_browser_automation=auto`
+- Browser exploration: `playwright-cli` not installed, so discovery used code + artifact analysis fallback
 
 ## Step 2 - Coverage Plan
+- Scope basis: Story AC1 and AC2
+- Coverage target: `critical-paths`
 
-### Targets by Level
+### API targets
+- `POST /api/v1/platform/_kernel/contracts/envelope/success`
+  - P0: canonical shared envelope helper contract shape (`ok=true`, `code`, `message`, `correlationId`, `tenantId`)
+- `POST /api/v1/platform/_kernel/contracts/envelope/business-refusal`
+  - P0: business refusal contract with HTTP 200 and `ok=false`
+  - P1: deterministic refusal content and no internal stack leakage
+- Cross-endpoint consistency
+  - P1: required top-level keys consistent between success and refusal envelopes
 
-- API (`@P0`, `@P1`)
-  - Reject state-changing requests when CSRF token is missing.
-  - Reject state-changing requests when CSRF token proof is invalid.
-  - Validate cookie policy matrix for `development` and `production` host topology.
+### E2E targets
+- P0: journey-level verification of business refusal semantics (HTTP 200 + `ok=false`)
+- P1: correlation-id consistency across success/refusal flows
+- P1: structured refusal fields stable for downstream UI adapters
 
-- Journey (`@P0`, `@P1`)
-  - State-changing guard behavior with missing CSRF proof.
-  - State-changing guard behavior with valid CSRF proof pair.
-  - Cookie bootstrap contract for parent-domain shared cookie attributes.
+## Step 3 - Parallel Generation + Aggregation
+- Subprocess outputs generated:
+  - `/tmp/tea-automate-api-tests-2026-02-17T19-52-18-200Z.json`
+  - `/tmp/tea-automate-e2e-tests-2026-02-17T19-52-18-200Z.json`
+- Aggregated summary generated:
+  - `/tmp/tea-automate-summary-2026-02-17T19-52-18-200Z.json`
 
-### Priority Mapping
+### Files updated
+- `tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts`
+  - Enabled 4 tests (removed `test.skip`)
+- `tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts`
+  - Enabled 3 tests (removed `test.skip`)
 
-- `@P0`: AC1 request rejection semantics on CSRF guard failures.
-- `@P1`: AC2 environment-safe cookie policy and successful guarded request behavior.
+### Fixture infrastructure
+- Reused existing shared fixture/factory stack (no additional scaffold required):
+  - `tests/support/fixtures/sharedApiEnvelope.fixture.ts`
+  - `tests/support/factories/sharedApiEnvelopeFactory.ts`
+  - `tests/support/helpers/apiClient.ts`
 
-## Step 3/3C - Generated and Aggregated Outputs
+### Aggregated totals
+- Total tests: 7
+  - API: 4
+  - E2E: 3
+- Priority coverage:
+  - P0: 3
+  - P1: 4
+  - P2: 0
+  - P3: 0
 
-### API Tests
+## Step 4 - Validation
+Checklist alignment:
+- Framework readiness: pass
+- Coverage mapping: pass (AC1 + AC2 explicitly covered)
+- Test quality structure: pass (priority tags, deterministic assertions, no hard waits)
+- Fixtures/factories/helpers: pass (existing reusable support layer)
+- CLI session cleanup: pass (CLI not used)
+- Temp artifacts location: pass (`/tmp` and `_bmad-output/test-artifacts`)
 
-- File updated: `/Users/jeremiahotis/moneyshyft/tests/api/platform/csrf-and-parent-domain-cookie-enforcement.api.spec.ts`
-- Converted skipped coverage to executable tests.
-- Executable tests now present: 4
-  - `@P0` rejects missing CSRF header
-  - `@P0` rejects invalid CSRF proof token
-  - `@P1` enforces development cookie policy matrix
-  - `@P1` enforces production cookie policy matrix
+## Assumptions and Risks
+- Assumption: Story 0.5 implementation and route registration for `_kernel/contracts/envelope/*` exist or will be landed before CI gate runs.
+- Risk: If endpoints are not implemented yet, newly enabled tests will fail as intended and should be treated as implementation gap signal.
 
-### Journey Tests
-
-- File updated: `/Users/jeremiahotis/moneyshyft/tests/e2e/platform/csrf-and-parent-domain-cookie-enforcement.spec.ts`
-- Converted skipped coverage to executable request-driven journey tests.
-- Executable tests now present: 3
-  - `@P0` blocks state-changing request without CSRF header
-  - `@P1` accepts state-changing request with valid CSRF proof pair
-  - `@P1` validates parent-domain cookie attributes from bootstrap contract
-
-### Fixture/Factory Reuse
-
-- `/Users/jeremiahotis/moneyshyft/tests/support/fixtures/csrfCookiePolicy.fixture.ts`
-- `/Users/jeremiahotis/moneyshyft/tests/support/factories/csrfCookiePolicyFactory.ts`
-- `/Users/jeremiahotis/moneyshyft/tests/support/helpers/apiClient.ts`
-
-## Step 4 - Validation and Risks
-
-Checklist validation status:
-- Framework scaffolding: PASS
-- Coverage mapping to ACs: PASS
-- Priority tagging: PASS
-- Duplicate-coverage control: PASS (API contracts plus journey-level contract checks)
-- Fixture/factory/helper usage: PASS
-- Browser session cleanup: PASS (no CLI browser sessions opened)
-- Temp artifact discipline: PASS (summary stored under `_bmad-output/test-artifacts`)
-
-Execution validation:
-- Command run:
-  - `npm run test:e2e -- tests/api/platform/csrf-and-parent-domain-cookie-enforcement.api.spec.ts tests/e2e/platform/csrf-and-parent-domain-cookie-enforcement.spec.ts`
-- Result: `7 failed` (0 passed)
-- Failure pattern: all 0.4 security endpoints returned `500` instead of expected contract statuses (`403`, `200`).
-- Interpretation: tests are executable and correctly wired into the suite, but backend story behavior is not yet meeting expected contracts.
-
-Assumptions and risks:
-- Endpoint contracts and refusal codes are expected to be implemented by story delivery.
-- Until kernel CSRF/cookie handlers are implemented, these tests should be treated as failing-acceptance coverage, not flaky tests.
-
-## Suggested Execution
-
-```bash
-npm run test:e2e -- tests/api/platform/csrf-and-parent-domain-cookie-enforcement.api.spec.ts
-npm run test:e2e -- tests/e2e/platform/csrf-and-parent-domain-cookie-enforcement.spec.ts
-```
-
-## Next Recommended Workflow
-
-- `RV` (`test-review`) after endpoint implementation to score determinism/quality.
-- `TR` (`trace`) to map AC coverage to pass/fail gate decisions.
+## Recommended Next Workflow
+- `RV` (Review Tests): run TEA test review for robustness scoring and anti-pattern scan.
+- `TR` (Trace Requirements): map Story 0.5 acceptance criteria to these 7 tests for gate decision.

--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
   testMatch: ['<rootDir>/src/**/__tests__/**/*.test.ts'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   clearMocks: true,
   transform: {

--- a/src/src/__tests__/apiEnvelopeContract.test.ts
+++ b/src/src/__tests__/apiEnvelopeContract.test.ts
@@ -4,6 +4,66 @@ import request from 'supertest';
 import { registerPlatformMiddleware } from '../api/registerRoutes';
 import contractsRouter from '../routes/api/v1/platform-contracts';
 
+const mockValidateRequest = jest.fn(() => (
+  (_req: express.Request, _res: express.Response, next: express.NextFunction) => next()
+));
+const mockAuthenticateToken = jest.fn(
+  (_req: express.Request, _res: express.Response, next: express.NextFunction) => next()
+);
+
+jest.mock('../services/AuthService', () => ({
+  __esModule: true,
+  default: {
+    signup: jest.fn(),
+    login: jest.fn(),
+    getUserById: jest.fn()
+  }
+}));
+
+jest.mock('../middleware/validate', () => ({
+  validateRequest: () => mockValidateRequest()
+}));
+
+jest.mock('../validators/auth.validators', () => ({
+  signupSchema: {},
+  loginSchema: {}
+}));
+
+jest.mock('../middleware/auth', () => ({
+  authenticateToken: (_req: express.Request, _res: express.Response, next: express.NextFunction) => (
+    mockAuthenticateToken(_req, _res, next)
+  )
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+jest.mock('../platform/sessions/PlatformSessionStore', () => ({
+  __esModule: true,
+  default: {
+    findSessionByRefreshToken: jest.fn(),
+    rotateSession: jest.fn(),
+    revokeSessionById: jest.fn(),
+    revokeSessionByRefreshToken: jest.fn()
+  }
+}));
+
+jest.mock('../utils/jwt', () => ({
+  setAuthCookies: jest.fn(),
+  clearAuthCookies: jest.fn(),
+  verifyRefreshToken: jest.fn(),
+  generateAccessToken: jest.fn(),
+  generateRefreshToken: jest.fn()
+}));
+
+import authRouter from '../routes/api/v1/auth';
+
 describe('Story 0.5 - shared API envelope and business refusal contract', () => {
   const buildApp = () => {
     const testApp = express();
@@ -11,6 +71,7 @@ describe('Story 0.5 - shared API envelope and business refusal contract', () => 
     testApp.use(express.json());
     registerPlatformMiddleware(testApp);
     testApp.use('/api/v1/platform', contractsRouter);
+    testApp.use('/api/v1/auth', authRouter);
     return testApp;
   };
 
@@ -35,6 +96,41 @@ describe('Story 0.5 - shared API envelope and business refusal contract', () => 
         correlationId: 'corr-envelope-alpha',
         tenantId: 'public',
         data: { mode: 'success' }
+      });
+    });
+
+    it('serializes module endpoint success responses through shared envelope helpers', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .post('/api/v1/auth/logout')
+        .set('x-correlation-id', 'corr-module-success-alpha');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'REQUEST_SUCCESS',
+        message: 'Logged out successfully',
+        correlationId: 'corr-module-success-alpha',
+        tenantId: 'public'
+      });
+    });
+
+    it('serializes module endpoint refusal responses through shared envelope helpers', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .post('/api/v1/auth/refresh')
+        .set('x-correlation-id', 'corr-module-refusal-alpha');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'HTTP_401',
+        message: 'Refresh token required',
+        refusalType: 'client',
+        correlationId: 'corr-module-refusal-alpha',
+        tenantId: 'public'
       });
     });
   });
@@ -63,6 +159,33 @@ describe('Story 0.5 - shared API envelope and business refusal contract', () => 
         data: { available: 42 }
       });
       expect(response.body).not.toHaveProperty('stack');
+    });
+  });
+
+  describe('shared system error contract helper', () => {
+    it('returns systemError envelope with explicit error type and status', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .post('/api/v1/platform/_kernel/contracts/envelope/system-error')
+        .set('x-correlation-id', 'corr-envelope-system-alpha')
+        .send({
+          code: 'ENVELOPE_SYSTEM_ERROR',
+          message: 'Unhandled exception while processing envelope contract',
+          data: { operation: 'post-envelope' },
+          httpStatus: 503
+        });
+
+      expect(response.status).toBe(503);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'ENVELOPE_SYSTEM_ERROR',
+        message: 'Unhandled exception while processing envelope contract',
+        errorType: 'system',
+        correlationId: 'corr-envelope-system-alpha',
+        tenantId: 'public',
+        data: { operation: 'post-envelope' }
+      });
     });
   });
 });

--- a/src/src/__tests__/apiEnvelopeContract.test.ts
+++ b/src/src/__tests__/apiEnvelopeContract.test.ts
@@ -1,0 +1,68 @@
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import request from 'supertest';
+import { registerPlatformMiddleware } from '../api/registerRoutes';
+import contractsRouter from '../routes/api/v1/platform-contracts';
+
+describe('Story 0.5 - shared API envelope and business refusal contract', () => {
+  const buildApp = () => {
+    const testApp = express();
+    testApp.use(cookieParser());
+    testApp.use(express.json());
+    registerPlatformMiddleware(testApp);
+    testApp.use('/api/v1/platform', contractsRouter);
+    return testApp;
+  };
+
+  describe('AC1: shared envelope helpers', () => {
+    it('returns canonical success envelope with code/message and request context', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .post('/api/v1/platform/_kernel/contracts/envelope/success')
+        .set('x-correlation-id', 'corr-envelope-alpha')
+        .send({
+          code: 'ENVELOPE_SUCCESS',
+          message: 'Envelope contract success',
+          data: { mode: 'success' }
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'ENVELOPE_SUCCESS',
+        message: 'Envelope contract success',
+        correlationId: 'corr-envelope-alpha',
+        tenantId: 'public',
+        data: { mode: 'success' }
+      });
+    });
+  });
+
+  describe('AC2: business refusal contract', () => {
+    it('returns HTTP 200 with ok=false and structured code/message for business refusals', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .post('/api/v1/platform/_kernel/contracts/envelope/business-refusal')
+        .set('x-correlation-id', 'corr-envelope-refusal-alpha')
+        .send({
+          code: 'ENVELOPE_BUSINESS_REFUSAL',
+          message: 'Requested amount exceeds available envelope balance',
+          data: { available: 42 }
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'ENVELOPE_BUSINESS_REFUSAL',
+        message: 'Requested amount exceeds available envelope balance',
+        refusalType: 'business',
+        correlationId: 'corr-envelope-refusal-alpha',
+        tenantId: 'public',
+        data: { available: 42 }
+      });
+      expect(response.body).not.toHaveProperty('stack');
+    });
+  });
+});

--- a/src/src/__tests__/app-entrypoint-kernel.test.ts
+++ b/src/src/__tests__/app-entrypoint-kernel.test.ts
@@ -67,6 +67,7 @@ describe('Story 0.1 - canonical app entrypoint and kernel middleware', () => {
       );
 
       expect(registeredPaths).toEqual([
+        '/api/v1/platform',
         '/api/v1/auth',
         '/api/v1/accounts',
         '/api/v1/transactions',

--- a/src/src/api/registerRoutes.ts
+++ b/src/src/api/registerRoutes.ts
@@ -24,6 +24,7 @@ export const PLATFORM_MIDDLEWARE_CHAIN = [
 ];
 
 export const V1_ROUTE_REGISTRATIONS: RouteRegistration[] = [
+  { path: '/api/v1/platform', modulePath: '../routes/api/v1/platform-contracts' },
   { path: '/api/v1/auth', modulePath: '../routes/api/v1/auth' },
   { path: '/api/v1/accounts', modulePath: '../routes/api/v1/accounts' },
   { path: '/api/v1/transactions', modulePath: '../routes/api/v1/transactions' },

--- a/src/src/platform/envelopes/response.ts
+++ b/src/src/platform/envelopes/response.ts
@@ -1,0 +1,70 @@
+import { Response } from 'express';
+
+type EnvelopeContext = {
+  correlationId: string | null;
+  tenantId: string | null;
+};
+
+type SuccessEnvelopeParams = {
+  code: string;
+  message: string;
+  data?: unknown;
+};
+
+type RefusalEnvelopeParams = {
+  code: string;
+  message: string;
+  data?: unknown;
+  refusalType?: 'business';
+};
+
+type ResponseLocalsEnvelope = {
+  responseEnvelope?: EnvelopeContext;
+};
+
+const resolveContext = (res: Response): EnvelopeContext => {
+  const locals = res.locals as ResponseLocalsEnvelope;
+  const envelope = locals.responseEnvelope;
+
+  return {
+    correlationId: envelope?.correlationId ?? null,
+    tenantId: envelope?.tenantId ?? null
+  };
+};
+
+export const success = (
+  res: Response,
+  { code, message, data }: SuccessEnvelopeParams
+): Response => {
+  const context = resolveContext(res);
+
+  const payload = {
+    ok: true,
+    code,
+    message,
+    correlationId: context.correlationId,
+    tenantId: context.tenantId,
+    ...(data !== undefined ? { data } : {})
+  };
+
+  return res.status(200).json(payload);
+};
+
+export const refusal = (
+  res: Response,
+  { code, message, data, refusalType = 'business' }: RefusalEnvelopeParams
+): Response => {
+  const context = resolveContext(res);
+
+  const payload = {
+    ok: false,
+    code,
+    message,
+    refusalType,
+    correlationId: context.correlationId,
+    tenantId: context.tenantId,
+    ...(data !== undefined ? { data } : {})
+  };
+
+  return res.status(200).json(payload);
+};

--- a/src/src/platform/envelopes/response.ts
+++ b/src/src/platform/envelopes/response.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 
-type EnvelopeContext = {
+export type EnvelopeContext = {
   correlationId: string | null;
   tenantId: string | null;
 };
@@ -9,18 +9,61 @@ type SuccessEnvelopeParams = {
   code: string;
   message: string;
   data?: unknown;
+  httpStatus?: number;
 };
 
 type RefusalEnvelopeParams = {
   code: string;
   message: string;
   data?: unknown;
-  refusalType?: 'business';
+  refusalType?: 'business' | 'client';
+  httpStatus?: number;
+};
+
+type SystemErrorEnvelopeParams = {
+  code: string;
+  message: string;
+  data?: unknown;
+  httpStatus?: number;
 };
 
 type ResponseLocalsEnvelope = {
   responseEnvelope?: EnvelopeContext;
 };
+
+export type SuccessEnvelopePayload = {
+  ok: true;
+  code: string;
+  message: string;
+  correlationId: string | null;
+  tenantId: string | null;
+  data?: unknown;
+};
+
+export type RefusalEnvelopePayload = {
+  ok: false;
+  code: string;
+  message: string;
+  refusalType: 'business' | 'client';
+  correlationId: string | null;
+  tenantId: string | null;
+  data?: unknown;
+};
+
+export type SystemErrorEnvelopePayload = {
+  ok: false;
+  code: string;
+  message: string;
+  errorType: 'system';
+  correlationId: string | null;
+  tenantId: string | null;
+  data?: unknown;
+};
+
+export type ApiEnvelopePayload =
+  | SuccessEnvelopePayload
+  | RefusalEnvelopePayload
+  | SystemErrorEnvelopePayload;
 
 const resolveContext = (res: Response): EnvelopeContext => {
   const locals = res.locals as ResponseLocalsEnvelope;
@@ -32,39 +75,85 @@ const resolveContext = (res: Response): EnvelopeContext => {
   };
 };
 
-export const success = (
-  res: Response,
-  { code, message, data }: SuccessEnvelopeParams
-): Response => {
-  const context = resolveContext(res);
+export const buildSuccessEnvelope = (
+  context: EnvelopeContext,
+  { code, message, data }: Omit<SuccessEnvelopeParams, 'httpStatus'>
+): SuccessEnvelopePayload => ({
+  ok: true,
+  code,
+  message,
+  correlationId: context.correlationId,
+  tenantId: context.tenantId,
+  ...(data !== undefined ? { data } : {})
+});
 
-  const payload = {
-    ok: true,
+export const buildRefusalEnvelope = (
+  context: EnvelopeContext,
+  {
     code,
     message,
-    correlationId: context.correlationId,
-    tenantId: context.tenantId,
-    ...(data !== undefined ? { data } : {})
-  };
+    data,
+    refusalType = 'business'
+  }: Omit<RefusalEnvelopeParams, 'httpStatus'>
+): RefusalEnvelopePayload => ({
+  ok: false,
+  code,
+  message,
+  refusalType,
+  correlationId: context.correlationId,
+  tenantId: context.tenantId,
+  ...(data !== undefined ? { data } : {})
+});
 
-  return res.status(200).json(payload);
+export const buildSystemErrorEnvelope = (
+  context: EnvelopeContext,
+  { code, message, data }: Omit<SystemErrorEnvelopeParams, 'httpStatus'>
+): SystemErrorEnvelopePayload => ({
+  ok: false,
+  code,
+  message,
+  errorType: 'system',
+  correlationId: context.correlationId,
+  tenantId: context.tenantId,
+  ...(data !== undefined ? { data } : {})
+});
+
+export const isEnvelopePayload = (value: unknown): value is ApiEnvelopePayload => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.ok === 'boolean'
+    && typeof candidate.code === 'string'
+    && typeof candidate.message === 'string'
+    && 'correlationId' in candidate
+    && 'tenantId' in candidate;
+};
+
+export const success = (
+  res: Response,
+  { httpStatus = 200, ...params }: SuccessEnvelopeParams
+): Response => {
+  const context = resolveContext(res);
+  const payload = buildSuccessEnvelope(context, params);
+  return res.status(httpStatus).json(payload);
 };
 
 export const refusal = (
   res: Response,
-  { code, message, data, refusalType = 'business' }: RefusalEnvelopeParams
+  { httpStatus = 200, ...params }: RefusalEnvelopeParams
 ): Response => {
   const context = resolveContext(res);
+  const payload = buildRefusalEnvelope(context, params);
+  return res.status(httpStatus).json(payload);
+};
 
-  const payload = {
-    ok: false,
-    code,
-    message,
-    refusalType,
-    correlationId: context.correlationId,
-    tenantId: context.tenantId,
-    ...(data !== undefined ? { data } : {})
-  };
-
-  return res.status(200).json(payload);
+export const systemError = (
+  res: Response,
+  { httpStatus = 500, ...params }: SystemErrorEnvelopeParams
+): Response => {
+  const context = resolveContext(res);
+  const payload = buildSystemErrorEnvelope(context, params);
+  return res.status(httpStatus).json(payload);
 };

--- a/src/src/platform/middleware/responseEnvelope.ts
+++ b/src/src/platform/middleware/responseEnvelope.ts
@@ -1,7 +1,15 @@
 import { NextFunction, Request, Response } from 'express';
+import {
+  buildRefusalEnvelope,
+  buildSuccessEnvelope,
+  buildSystemErrorEnvelope,
+  EnvelopeContext,
+  isEnvelopePayload
+} from '../envelopes/response';
 
 type ResponseLocalsWithChain = {
   platformMiddlewareChain?: string[];
+  responseEnvelope?: EnvelopeContext;
 };
 
 const recordChainStep = (res: Response, step: string): string[] => {
@@ -20,14 +28,130 @@ export const responseEnvelope = (req: Request, res: Response, next: NextFunction
   }
 
   res.locals.responseEnvelope = {
-    ok: true,
     correlationId: req.correlationId || null,
     tenantId: req.tenantId || null
   };
+
+  // Normalize only API responses to preserve legacy health/debug payloads.
+  if (req.path.startsWith('/api/')) {
+    const originalJson = res.json.bind(res);
+    const originalStatus = res.status.bind(res);
+
+    res.json = ((body: unknown): Response => {
+      if (isEnvelopePayload(body)) {
+        return originalJson(body);
+      }
+
+      const statusCode = res.statusCode || 200;
+      const context = res.locals.responseEnvelope || {
+        correlationId: null,
+        tenantId: null
+      };
+      const message = deriveMessage(body, statusCode);
+      const code = deriveCode(body, statusCode);
+      const data = extractData(body);
+
+      if (statusCode >= 500) {
+        const payload = buildSystemErrorEnvelope(context, {
+          code,
+          message,
+          ...(data !== undefined ? { data } : {})
+        });
+        originalStatus(statusCode);
+        return originalJson(payload);
+      }
+
+      if (statusCode >= 400) {
+        const payload = buildRefusalEnvelope(context, {
+          code,
+          message,
+          refusalType: 'client',
+          ...(data !== undefined ? { data } : {})
+        });
+        originalStatus(statusCode);
+        return originalJson(payload);
+      }
+
+      const payload = buildSuccessEnvelope(context, {
+        code,
+        message,
+        ...(data !== undefined ? { data } : {})
+      });
+      originalStatus(statusCode);
+      return originalJson(payload);
+    }) as Response['json'];
+  }
 
   next();
 };
 
 export const pushPlatformChainStep = (res: Response, step: string): void => {
   recordChainStep(res, step);
+};
+
+const normalizeText = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+};
+
+const extractData = (body: unknown): unknown => {
+  if (!body || typeof body !== 'object') {
+    return undefined;
+  }
+
+  const record = body as Record<string, unknown>;
+  if ('data' in record && record.data !== undefined) {
+    return record.data;
+  }
+
+  const { code, error, message, ...rest } = record;
+  void code;
+  void error;
+  void message;
+
+  return Object.keys(rest).length > 0 ? rest : undefined;
+};
+
+const deriveMessage = (body: unknown, statusCode: number): string => {
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>;
+    return normalizeText(record.message)
+      || normalizeText(record.error)
+      || defaultMessage(statusCode);
+  }
+
+  return normalizeText(body) || defaultMessage(statusCode);
+};
+
+const deriveCode = (body: unknown, statusCode: number): string => {
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>;
+    const explicitCode = normalizeText(record.code);
+
+    if (explicitCode) {
+      return explicitCode;
+    }
+  }
+
+  if (statusCode >= 400) {
+    return `HTTP_${statusCode}`;
+  }
+
+  return statusCode === 200 ? 'REQUEST_SUCCESS' : `HTTP_${statusCode}`;
+};
+
+const defaultMessage = (statusCode: number): string => {
+  if (statusCode >= 500) {
+    return 'Internal server error';
+  }
+
+  if (statusCode >= 400) {
+    return 'Request refused';
+  }
+
+  return 'Request succeeded';
 };

--- a/src/src/routes/api/v1/platform-contracts.ts
+++ b/src/src/routes/api/v1/platform-contracts.ts
@@ -1,0 +1,36 @@
+import { Request, Response, Router } from 'express';
+import { refusal, success } from '../../../platform/envelopes/response';
+
+const router = Router();
+
+router.post('/_kernel/contracts/envelope/success', (req: Request, res: Response) => {
+  const code = typeof req.body?.code === 'string' && req.body.code.trim() !== ''
+    ? req.body.code
+    : 'ENVELOPE_SUCCESS';
+  const message = typeof req.body?.message === 'string' && req.body.message.trim() !== ''
+    ? req.body.message
+    : 'Envelope contract success';
+
+  return success(res, {
+    code,
+    message,
+    data: req.body?.data
+  });
+});
+
+router.post('/_kernel/contracts/envelope/business-refusal', (req: Request, res: Response) => {
+  const code = typeof req.body?.code === 'string' && req.body.code.trim() !== ''
+    ? req.body.code
+    : 'ENVELOPE_BUSINESS_REFUSAL';
+  const message = typeof req.body?.message === 'string' && req.body.message.trim() !== ''
+    ? req.body.message
+    : 'Requested amount exceeds available envelope balance';
+
+  return refusal(res, {
+    code,
+    message,
+    data: req.body?.data
+  });
+});
+
+export default router;

--- a/src/src/routes/api/v1/platform-contracts.ts
+++ b/src/src/routes/api/v1/platform-contracts.ts
@@ -1,5 +1,5 @@
 import { Request, Response, Router } from 'express';
-import { refusal, success } from '../../../platform/envelopes/response';
+import { refusal, success, systemError } from '../../../platform/envelopes/response';
 
 const router = Router();
 
@@ -30,6 +30,27 @@ router.post('/_kernel/contracts/envelope/business-refusal', (req: Request, res: 
     code,
     message,
     data: req.body?.data
+  });
+});
+
+router.post('/_kernel/contracts/envelope/system-error', (req: Request, res: Response) => {
+  const code = typeof req.body?.code === 'string' && req.body.code.trim() !== ''
+    ? req.body.code
+    : 'ENVELOPE_SYSTEM_ERROR';
+  const message = typeof req.body?.message === 'string' && req.body.message.trim() !== ''
+    ? req.body.message
+    : 'Unhandled exception while processing envelope contract';
+  const httpStatus = typeof req.body?.httpStatus === 'number'
+    && Number.isInteger(req.body.httpStatus)
+    && req.body.httpStatus >= 500
+    ? req.body.httpStatus
+    : 500;
+
+  return systemError(res, {
+    code,
+    message,
+    data: req.body?.data,
+    httpStatus
   });
 });
 

--- a/tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts
+++ b/tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest } from '../../support/helpers/apiClient';
+import {
+  createBusinessRefusalProbe,
+  createSharedEnvelopeHeaders,
+  createSharedEnvelopeSuccessProbe,
+} from '../../support/factories/sharedApiEnvelopeFactory';
+
+test.describe('Story 0.5 atdd - shared API envelope and business refusal contract API coverage', () => {
+  test('returns canonical success envelope using shared helper contract @P0', async ({ request }) => {
+    // Given a valid platform request context and success probe payload
+    const headers = createSharedEnvelopeHeaders({
+      tenantId: 'tenant-envelope-alpha',
+      correlationId: 'corr-envelope-alpha',
+    });
+    const successProbe = createSharedEnvelopeSuccessProbe();
+
+    // When the shared success envelope contract endpoint is called
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/success',
+      headers,
+      data: successProbe.payload,
+    });
+
+    // Then a structured shared success envelope contract is returned
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: true,
+      code: successProbe.expected.code,
+      message: successProbe.expected.message,
+      correlationId: headers['x-correlation-id'],
+      tenantId: headers['x-tenant-id'],
+    });
+  });
+
+  test('returns business refusal contract as HTTP 200 with structured code/message @P0', async ({ request }) => {
+    // Given a request that should violate a business envelope rule
+    const headers = createSharedEnvelopeHeaders({
+      tenantId: 'tenant-envelope-alpha',
+      correlationId: 'corr-envelope-refusal-alpha',
+    });
+    const refusalProbe = createBusinessRefusalProbe();
+
+    // When the business refusal contract endpoint is called
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',
+      headers,
+      data: refusalProbe.payload,
+    });
+
+    // Then HTTP 200 is preserved with structured refusal semantics
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: false,
+      code: refusalProbe.expected.code,
+      message: refusalProbe.expected.message,
+      refusalType: refusalProbe.expected.refusalType,
+      correlationId: headers['x-correlation-id'],
+      tenantId: headers['x-tenant-id'],
+    });
+  });
+
+  test('keeps shared envelope shape consistent between success and business refusal contracts @P1', async ({ request }) => {
+    // Given one request context reused across success and refusal probes
+    const headers = createSharedEnvelopeHeaders({
+      tenantId: 'tenant-envelope-consistency',
+      correlationId: 'corr-envelope-consistency',
+    });
+    const successProbe = createSharedEnvelopeSuccessProbe();
+    const refusalProbe = createBusinessRefusalProbe();
+
+    // When both contract endpoints are called
+    const successResponse = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/success',
+      headers,
+      data: successProbe.payload,
+    });
+    const refusalResponse = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',
+      headers,
+      data: refusalProbe.payload,
+    });
+
+    // Then they both emit the canonical top-level envelope contract keys
+    expect(successResponse.status()).toBe(200);
+    expect(refusalResponse.status()).toBe(200);
+
+    const successBody = await successResponse.json();
+    const refusalBody = await refusalResponse.json();
+    const requiredKeys = ['ok', 'code', 'message', 'correlationId', 'tenantId'];
+
+    expect(requiredKeys.every((key) => Object.prototype.hasOwnProperty.call(successBody, key))).toBe(true);
+    expect(requiredKeys.every((key) => Object.prototype.hasOwnProperty.call(refusalBody, key))).toBe(true);
+  });
+
+  test('keeps refusal envelopes deterministic and free of internal stack leakage @P1', async ({ request }) => {
+    // Given a deterministic refusal probe payload
+    const headers = createSharedEnvelopeHeaders({
+      tenantId: 'tenant-envelope-hardening',
+      correlationId: 'corr-envelope-hardening',
+    });
+    const refusalProbe = createBusinessRefusalProbe({
+      code: 'ENVELOPE_BUSINESS_REFUSAL',
+      message: 'Requested amount exceeds available envelope balance',
+    });
+
+    // When the refusal contract endpoint is called repeatedly with same input
+    const firstResponse = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',
+      headers,
+      data: refusalProbe.payload,
+    });
+    const secondResponse = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',
+      headers,
+      data: refusalProbe.payload,
+    });
+
+    // Then structured refusal fields remain stable and implementation details are hidden
+    expect(firstResponse.status()).toBe(200);
+    expect(secondResponse.status()).toBe(200);
+
+    const firstBody = await firstResponse.json();
+    const secondBody = await secondResponse.json();
+
+    expect(firstBody).toMatchObject({
+      ok: false,
+      code: refusalProbe.expected.code,
+      message: refusalProbe.expected.message,
+      refusalType: 'business',
+    });
+    expect(secondBody).toMatchObject({
+      ok: false,
+      code: refusalProbe.expected.code,
+      message: refusalProbe.expected.message,
+      refusalType: 'business',
+    });
+    expect(firstBody).not.toHaveProperty('stack');
+    expect(secondBody).not.toHaveProperty('stack');
+  });
+});

--- a/tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts
+++ b/tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts
@@ -1,0 +1,86 @@
+import { apiRequest } from '../../support/helpers/apiClient';
+import { test, expect } from '../../support/fixtures/sharedApiEnvelope.fixture';
+
+test.describe('Story 0.5 atdd - shared API envelope and business refusal contract journey', () => {
+  test('keeps HTTP 200 semantics for business refusals in journey flow @P0', async ({
+    request,
+    sharedEnvelopeHeaders,
+    businessRefusalProbe,
+  }) => {
+    // Given a browser-driven journey that triggers a business refusal contract path
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',
+      headers: sharedEnvelopeHeaders,
+      data: businessRefusalProbe.payload,
+    });
+
+    // Then refusal is represented as a business contract (HTTP 200 + ok=false)
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: false,
+      code: businessRefusalProbe.expected.code,
+      message: businessRefusalProbe.expected.message,
+      refusalType: businessRefusalProbe.expected.refusalType,
+    });
+  });
+
+  test('echoes correlation id consistently across success and refusal envelope paths @P1', async ({
+    request,
+    sharedEnvelopeHeaders,
+    sharedSuccessProbe,
+    businessRefusalProbe,
+  }) => {
+    // Given one request correlation context across multiple contract paths
+    const successResponse = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/success',
+      headers: sharedEnvelopeHeaders,
+      data: sharedSuccessProbe.payload,
+    });
+    const refusalResponse = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',
+      headers: sharedEnvelopeHeaders,
+      data: businessRefusalProbe.payload,
+    });
+
+    // Then both responses should preserve the same correlation id
+    expect(successResponse.status()).toBe(200);
+    expect(refusalResponse.status()).toBe(200);
+
+    const successBody = await successResponse.json();
+    const refusalBody = await refusalResponse.json();
+
+    expect(successBody.correlationId).toBe(sharedEnvelopeHeaders['x-correlation-id']);
+    expect(refusalBody.correlationId).toBe(sharedEnvelopeHeaders['x-correlation-id']);
+  });
+
+  test('exposes structured refusal fields for downstream UI adapters @P1', async ({
+    request,
+    sharedEnvelopeHeaders,
+    businessRefusalProbe,
+  }) => {
+    // Given a refusal scenario used by downstream UI adapters
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/_kernel/contracts/envelope/business-refusal',
+      headers: sharedEnvelopeHeaders,
+      data: businessRefusalProbe.payload,
+    });
+
+    // Then response contains deterministic contract fields for rendering and localization
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      ok: false,
+      code: businessRefusalProbe.expected.code,
+      message: businessRefusalProbe.expected.message,
+      refusalType: businessRefusalProbe.expected.refusalType,
+    });
+    expect(typeof body.message).toBe('string');
+    expect(body.message.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/support/factories/sharedApiEnvelopeFactory.ts
+++ b/tests/support/factories/sharedApiEnvelopeFactory.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+
+type SharedEnvelopeHeaderOverrides = {
+  tenantId?: string;
+  correlationId?: string;
+  csrfToken?: string;
+};
+
+type SuccessProbeOverrides = {
+  operationName?: string;
+};
+
+type BusinessRefusalProbeOverrides = {
+  requestedAmountCents?: number;
+  availableAmountCents?: number;
+  ruleName?: string;
+  code?: string;
+  message?: string;
+};
+
+export function createSharedEnvelopeHeaders(
+  overrides: SharedEnvelopeHeaderOverrides = {},
+): Record<string, string> {
+  const tenantId = overrides.tenantId ?? `tenant-${randomUUID()}`;
+  const correlationId = overrides.correlationId ?? `corr-${randomUUID()}`;
+  const csrfToken = overrides.csrfToken ?? `csrf-${randomUUID()}`;
+
+  return {
+    'x-tenant-id': tenantId,
+    'x-correlation-id': correlationId,
+    'x-csrf-token': csrfToken,
+  };
+}
+
+export function createSharedEnvelopeSuccessProbe(
+  overrides: SuccessProbeOverrides = {},
+) {
+  const operationName = overrides.operationName ?? 'contract-health-check';
+
+  return {
+    payload: {
+      action: 'platform-envelope-success-probe',
+      operationName,
+      requestId: `req-${randomUUID()}`,
+    },
+    expected: {
+      code: 'ENVELOPE_CONTRACT_OK',
+      message: 'Shared envelope helper returned success contract',
+    },
+  };
+}
+
+export function createBusinessRefusalProbe(
+  overrides: BusinessRefusalProbeOverrides = {},
+) {
+  const requestedAmountCents = overrides.requestedAmountCents ?? 15_000;
+  const availableAmountCents = overrides.availableAmountCents ?? 5_000;
+  const ruleName = overrides.ruleName ?? 'available-funds-must-cover-request';
+  const code = overrides.code ?? 'ENVELOPE_BUSINESS_REFUSAL';
+  const message =
+    overrides.message ??
+    'Requested amount exceeds available envelope balance';
+
+  return {
+    payload: {
+      action: 'platform-envelope-business-refusal-probe',
+      requestedAmountCents,
+      availableAmountCents,
+      ruleName,
+    },
+    expected: {
+      code,
+      message,
+      refusalType: 'business' as const,
+    },
+  };
+}

--- a/tests/support/fixtures/sharedApiEnvelope.fixture.ts
+++ b/tests/support/fixtures/sharedApiEnvelope.fixture.ts
@@ -1,0 +1,26 @@
+import { test as base } from '@playwright/test';
+import {
+  createBusinessRefusalProbe,
+  createSharedEnvelopeHeaders,
+  createSharedEnvelopeSuccessProbe,
+} from '../factories/sharedApiEnvelopeFactory';
+
+type SharedApiEnvelopeFixtures = {
+  sharedEnvelopeHeaders: ReturnType<typeof createSharedEnvelopeHeaders>;
+  sharedSuccessProbe: ReturnType<typeof createSharedEnvelopeSuccessProbe>;
+  businessRefusalProbe: ReturnType<typeof createBusinessRefusalProbe>;
+};
+
+export const test = base.extend<SharedApiEnvelopeFixtures>({
+  sharedEnvelopeHeaders: async ({}, use) => {
+    await use(createSharedEnvelopeHeaders());
+  },
+  sharedSuccessProbe: async ({}, use) => {
+    await use(createSharedEnvelopeSuccessProbe());
+  },
+  businessRefusalProbe: async ({}, use) => {
+    await use(createBusinessRefusalProbe());
+  },
+});
+
+export { expect } from '@playwright/test';


### PR DESCRIPTION
## Summary
- implement shared systemError API envelope helper and expose contract endpoint
- enforce shared envelope serialization for /api/* responses through responseEnvelope middleware
- expand Story 0.5 contract tests to cover module route success/refusal serialization and system-error payloads
- reconcile Story 0.5 implementation artifact and sprint tracking with actual git changes

## Findings Resolved
1. AC1 now enforced beyond canary routes via API response normalization
2. missing systemError helper implemented
3. test coverage expanded from synthetic-only endpoints to real module routes
4. story File List/git discrepancy reconciled

## Validation
- cd src && npm test -- --runInBand src/__tests__/apiEnvelopeContract.test.ts
- cd src && npm test -- --runInBand src/__tests__/app-entrypoint-kernel.test.ts
- cd src && npm test -- --runInBand
- cd src && npm run build
