### PR TITLE
Fix: harden outbox schema and close story 0.6 review

### DIFF
--- a/_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md
+++ b/_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md
@@ -1,6 +1,6 @@
 # Story 0.6: Platform Events and Outbox Schema Foundations
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -17,10 +17,10 @@ so that all write paths can emit integration-safe records..
 
 ## Tasks / Subtasks
 
-- [ ] Implement acceptance criterion 1 (AC: 1)
-  - [ ] Add automated coverage for AC 1
-- [ ] Implement acceptance criterion 2 (AC: 2)
-  - [ ] Add automated coverage for AC 2
+- [x] Implement acceptance criterion 1 (AC: 1)
+  - [x] Add automated coverage for AC 1
+- [x] Implement acceptance criterion 2 (AC: 2)
+  - [x] Add automated coverage for AC 2
 
 ## Dev Notes
 
@@ -49,12 +49,25 @@ GPT-5 Codex
 
 ### Debug Log References
 
--
+- `cd src && npm test -- --runInBand src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts` (RED: module not found before migration, then GREEN)
+- `cd src && npm test -- --runInBand` (full backend regression suite)
 
 ### Completion Notes List
 
--
+- Added migration `src/src/migrations/20260217113000_create_platform_events_and_outbox.ts` creating canonical `platform.events` and `platform.outbox_events` tables.
+- Implemented required lineage fields on `platform.events`: `event_name`, `tenant_id`, `actor_id`, `entity_type`, `entity_id`, `occurred_at_utc`, and `payload`.
+- Implemented required delivery + lineage fields on `platform.outbox_events`, including `delivery_status`, `delivery_attempts`, `available_at_utc`, `delivered_at_utc`, `last_delivery_error`, and immutable event linkage via `event_id`.
+- Added operational/replay indexes for events and outbox polling/replay query patterns.
+- Added automated migration contract coverage in `src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts` for AC1 and AC2.
+- Verified no regressions with full Jest suite: 13/13 suites passing, 41/41 tests passing.
 
 ### File List
 
--
+- src/src/migrations/20260217113000_create_platform_events_and_outbox.ts
+- src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts
+- _bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+
+## Change Log
+
+- 2026-02-17: Implemented Story 0.6 by adding canonical platform events/outbox migration with lineage+delivery fields, replay/operational indexes, and automated migration coverage; story moved to `review`.

--- a/_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md
+++ b/_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md
@@ -1,6 +1,6 @@
 # Story 0.6: Platform Events and Outbox Schema Foundations
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -51,6 +51,8 @@ GPT-5 Codex
 
 - `cd src && npm test -- --runInBand src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts` (RED: module not found before migration, then GREEN)
 - `cd src && npm test -- --runInBand` (full backend regression suite)
+- `cd src && npm test -- --runInBand src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts` (post-review hardening verification)
+- `cd src && npm test -- --runInBand` (post-review full backend regression suite)
 
 ### Completion Notes List
 
@@ -58,7 +60,11 @@ GPT-5 Codex
 - Implemented required lineage fields on `platform.events`: `event_name`, `tenant_id`, `actor_id`, `entity_type`, `entity_id`, `occurred_at_utc`, and `payload`.
 - Implemented required delivery + lineage fields on `platform.outbox_events`, including `delivery_status`, `delivery_attempts`, `available_at_utc`, `delivered_at_utc`, `last_delivery_error`, and immutable event linkage via `event_id`.
 - Added operational/replay indexes for events and outbox polling/replay query patterns.
+- Hardened outbox schema invariants with DB-level checks for allowed `delivery_status` values and non-negative `delivery_attempts`.
+- Added lease-aware outbox index on (`delivery_status`, `available_at_utc`, `leased_until_utc`) for worker polling and lease expiry scanning.
+- Added trigger-backed `updated_at` maintenance for `platform.outbox_events` plus rollback-safe trigger/function teardown.
 - Added automated migration contract coverage in `src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts` for AC1 and AC2.
+- Expanded migration tests to verify FK/uniqueness semantics, DB constraint creation, lease index presence, and trigger lifecycle calls.
 - Verified no regressions with full Jest suite: 13/13 suites passing, 41/41 tests passing.
 
 ### File List
@@ -68,6 +74,11 @@ GPT-5 Codex
 - _bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md
 - _bmad-output/implementation-artifacts/sprint-status.yaml
 
+### Senior Developer Review (AI)
+
+- 2026-02-17: Resolved 1 high + 3 medium findings from adversarial review by adding DB guardrails, lease-aware indexing, `updated_at` trigger enforcement, and stronger migration contract assertions.
+
 ## Change Log
 
 - 2026-02-17: Implemented Story 0.6 by adding canonical platform events/outbox migration with lineage+delivery fields, replay/operational indexes, and automated migration coverage; story moved to `review`.
+- 2026-02-17: Code review remediation complete; story moved to `done` with schema hardening and expanded test coverage.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -46,7 +46,7 @@ development_status:
   0-3-platform-session-store-and-refresh-rotation: review
   0-4-csrf-and-parent-domain-cookie-enforcement: done
   0-5-shared-api-envelope-and-business-refusal-contract: done
-  0-6-platform-events-and-outbox-schema-foundations: review
+  0-6-platform-events-and-outbox-schema-foundations: done
   0-7-mutation-transaction-wrapper-with-mandatory-event-outbox-writes: ready-for-dev
   0-8-centralized-time-service-and-utc-local-rendering-contract: ready-for-dev
   0-9-ci-policy-gate-as-blocking-first-stage: ready-for-dev

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -46,7 +46,7 @@ development_status:
   0-3-platform-session-store-and-refresh-rotation: review
   0-4-csrf-and-parent-domain-cookie-enforcement: done
   0-5-shared-api-envelope-and-business-refusal-contract: done
-  0-6-platform-events-and-outbox-schema-foundations: ready-for-dev
+  0-6-platform-events-and-outbox-schema-foundations: review
   0-7-mutation-transaction-wrapper-with-mandatory-event-outbox-writes: ready-for-dev
   0-8-centralized-time-service-and-utc-local-rendering-contract: ready-for-dev
   0-9-ci-policy-gate-as-blocking-first-stage: ready-for-dev

--- a/_bmad-output/test-artifacts/atdd-checklist-0-6.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-0-6.md
@@ -1,0 +1,301 @@
+---
+stepsCompleted:
+  - step-01-preflight-and-context
+  - step-02-generation-mode
+  - step-03-test-strategy
+  - step-04c-aggregate
+  - step-05-validate-and-complete
+lastStep: step-05-validate-and-complete
+lastSaved: '2026-02-17T21:09:58Z'
+storyId: '0-6'
+storyFile: '/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md'
+generationMode: 'ai-generation'
+tddPhase: 'RED'
+subprocessTimestamp: '2026-02-17T21-09-58Z'
+---
+
+# ATDD Checklist - Epic 0, Story 6: Platform Events and Outbox Schema Foundations
+
+**Date:** 2026-02-17
+**Author:** Jeremiah
+**Primary Test Level:** API
+
+---
+
+## Workflow Progress Log
+
+### Step 1 - Preflight and Context
+
+- Story loaded: `/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md`
+- Framework config loaded: `/Users/jeremiahotis/moneyshyft/playwright.config.ts`
+- Test patterns reviewed under `/Users/jeremiahotis/moneyshyft/tests`
+- Required policy gates passed on branch: `codex/story-0-6-platform-events-and-outbox-schema-foundations`
+  - `npm run policy:check`
+  - `npm run branch:ensure-workflow -- --workflow _bmad/tea/workflows/testarch/atdd/workflow.yaml --story _bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md`
+- TEA flags:
+  - `tea_use_playwright_utils: true`
+  - `tea_browser_automation: auto`
+
+Knowledge fragments loaded:
+- Core: `data-factories`, `component-tdd`, `test-quality`, `test-healing-patterns`, `selector-resilience`, `timing-debugging`
+- Playwright Utils: `overview`, `api-request`, `network-recorder`, `auth-session`, `intercept-network-call`, `recurse`, `log`, `file-utils`, `network-error-monitor`, `fixtures-composition`
+- Browser automation: `playwright-cli`
+
+### Step 2 - Generation Mode
+
+Selected mode: **AI generation**
+
+Reasoning:
+- Acceptance criteria are backend schema/index contract focused and can be represented deterministically with API-first RED tests.
+- Existing platform test patterns under `tests/api/platform` and `tests/e2e/platform` support consistent naming and fixture composition.
+- Recording mode is unnecessary because no UI flow is required in this story scope.
+
+### Step 3 - Test Strategy
+
+Acceptance criteria mapped to scenarios:
+
+1. Canonical schema contract for `platform.events` exposes required lineage fields.
+2. Canonical schema contract for `platform.outbox_events` exposes delivery/replay fields.
+3. Operational/replay index metadata is available for deterministic querying.
+4. Replay query semantics are explicit for downstream operators/dispatch tooling.
+
+Test levels selected:
+- API (P0/P1): schema/index contract assertions and replay metadata
+- E2E (P0/P1): integration-journey contract continuity for schema + index consumers
+
+Priority allocation:
+- P0: events/outbox schema contracts
+- P1: index and replay query contract consistency
+
+RED-phase enforcement:
+- All generated tests use `test.skip(...)` intentionally.
+- Assertions target expected final schema and index contract behavior.
+
+---
+
+## Story Summary
+
+Story 0.6 establishes canonical platform event and outbox schema foundations so future mutation wrappers can enforce event/outbox discipline. The RED-phase tests define the API contract for schema lineage fields and replay-ready index metadata before implementation lands.
+
+**As a** platform architect  
+**I want** canonical `platform.events` and `platform.outbox_events` schemas  
+**So that** all write paths can emit integration-safe records
+
+---
+
+## Acceptance Criteria
+
+1. events and outbox tables exist with required lineage and delivery fields
+2. indexes support operational and replay queries
+
+---
+
+## Failing Tests Created (RED Phase)
+
+### API Tests (4 tests)
+
+**File:** `tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts` (113 lines)
+
+- ✅ **Test:** `returns canonical platform.events lineage schema contract @P0`
+  - **Status:** RED - expected failure until events schema contract endpoint exists
+  - **Verifies:** canonical events lineage fields and table identity
+- ✅ **Test:** `returns canonical platform.outbox_events delivery schema contract @P0`
+  - **Status:** RED - expected failure until outbox schema contract endpoint exists
+  - **Verifies:** canonical outbox delivery/replay fields and table identity
+- ✅ **Test:** `returns operational and replay index contract metadata for events/outbox @P1`
+  - **Status:** RED - expected failure until index metadata endpoint exists
+  - **Verifies:** required index sets for operational and replay query patterns
+- ✅ **Test:** `exposes replay cursor semantics for pending outbox delivery queries @P1`
+  - **Status:** RED - expected failure until replay-query contract endpoint exists
+  - **Verifies:** deterministic outbox replay query keys and ordering contract
+
+### E2E Tests (3 tests)
+
+**File:** `tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts` (83 lines)
+
+- ✅ **Test:** `returns schema contracts for events and outbox in one integration-safe journey @P0`
+  - **Status:** RED - expected failure until both schema endpoints are implemented
+  - **Verifies:** combined schema contract availability across one journey context
+- ✅ **Test:** `keeps correlation metadata stable across schema and index contract endpoints @P1`
+  - **Status:** RED - expected failure until correlation propagation is implemented
+  - **Verifies:** correlation continuity across schema and index contract responses
+- ✅ **Test:** `exposes replay-ready outbox index hints for operator tooling adapters @P1`
+  - **Status:** RED - expected failure until outbox index metadata endpoint is implemented
+  - **Verifies:** deterministic outbox index hints for replay-oriented adapters
+
+### Component Tests (0 tests)
+
+No component-level tests were generated because Story 0.6 scope is backend schema/index foundations.
+
+---
+
+## Data Factories Created
+
+### Platform Event/Outbox Contract Factory
+
+**File:** `tests/support/factories/platformEventOutboxFactory.ts`
+
+**Exports:**
+
+- `createPlatformContractHeaders(overrides?)`
+- `createEventSchemaExpectation(overrides?)`
+- `createOutboxSchemaExpectation(overrides?)`
+- `createOperationalIndexExpectations()`
+
+---
+
+## Fixtures Created
+
+### Platform Event/Outbox Fixture
+
+**File:** `tests/support/fixtures/platformEventOutbox.fixture.ts`
+
+**Fixtures:**
+
+- `platformContractHeaders`
+- `eventSchemaExpectation`
+- `outboxSchemaExpectation`
+- `operationalIndexExpectations`
+
+---
+
+## Mock Requirements
+
+External mocks are not required for this story.
+
+Expected kernel contract endpoints (to implement):
+- `GET /api/v1/platform/_kernel/contracts/events/schema`
+- `GET /api/v1/platform/_kernel/contracts/outbox/schema`
+- `GET /api/v1/platform/_kernel/contracts/events-outbox/indexes`
+- `GET /api/v1/platform/_kernel/contracts/outbox/replay-query`
+
+---
+
+## Required data-testid Attributes
+
+No UI selectors are required for this story in ATDD RED phase.
+
+---
+
+## Implementation Checklist
+
+### Test Group: Events Schema Contract
+
+**File:** `tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts`
+
+**Tasks to make this test group pass:**
+
+- [ ] Add migration(s) for `platform.events` with required lineage fields
+- [ ] Implement `GET /api/v1/platform/_kernel/contracts/events/schema`
+- [ ] Return canonical schema contract payload with deterministic field list
+- [ ] Remove `test.skip()` from events schema tests
+- [ ] Run: `npm run test:e2e -- tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts`
+- [ ] ✅ Tests pass
+
+### Test Group: Outbox Schema and Replay Contract
+
+**File:** `tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts`
+
+**Tasks to make this test group pass:**
+
+- [ ] Add migration(s) for `platform.outbox_events` with delivery/replay fields
+- [ ] Add required operational and replay indexes
+- [ ] Implement `GET /api/v1/platform/_kernel/contracts/outbox/schema`
+- [ ] Implement `GET /api/v1/platform/_kernel/contracts/events-outbox/indexes`
+- [ ] Implement `GET /api/v1/platform/_kernel/contracts/outbox/replay-query`
+- [ ] Remove `test.skip()` from outbox/index API tests
+- [ ] Run: `npm run test:e2e -- tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts`
+- [ ] ✅ Tests pass
+
+### Test Group: Journey-Level Contract Consistency
+
+**File:** `tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts`
+
+**Tasks to make this test group pass:**
+
+- [ ] Ensure schema and index endpoints preserve correlation metadata
+- [ ] Ensure journey context can request both schema contracts consistently
+- [ ] Remove `test.skip()` from E2E journey tests
+- [ ] Run: `npm run test:e2e -- tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts`
+- [ ] ✅ Tests pass
+
+---
+
+## Running Tests
+
+```bash
+# Run story 0.6 generated ATDD specs
+npm run test:e2e -- tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts
+
+# Run API spec only
+npm run test:e2e -- tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts
+
+# Run E2E spec only
+npm run test:e2e -- tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts
+
+# Run headed mode
+npm run test:e2e:headed -- tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts
+```
+
+---
+
+## Red-Green-Refactor Workflow
+
+### RED Phase (Complete) ✅
+
+- RED-phase schema and index contract tests generated for API and journey levels.
+- Tests are intentionally `test.skip()` while implementation is missing.
+- Assertions are concrete and deterministic for expected behavior.
+
+### GREEN Phase (Next)
+
+1. Implement migrations and contract endpoints for events/outbox schema + indexes.
+2. Remove `test.skip()` incrementally (P0 before P1).
+3. Verify API tests green, then journey tests green.
+
+### REFACTOR Phase (After Green)
+
+1. Consolidate schema contract serializers into platform kernel utilities.
+2. Keep schema/index contract payloads versioned and deterministic.
+3. Remove duplication across API and journey contract test fixtures.
+
+---
+
+## Test Execution Evidence
+
+Generation artifacts:
+
+- `/Users/jeremiahotis/moneyshyft/_bmad-output/test-artifacts/atdd-temp/tea-atdd-api-tests-2026-02-17T21-09-58Z.json`
+- `/Users/jeremiahotis/moneyshyft/_bmad-output/test-artifacts/atdd-temp/tea-atdd-e2e-tests-2026-02-17T21-09-58Z.json`
+- `/Users/jeremiahotis/moneyshyft/_bmad-output/test-artifacts/atdd-temp/tea-atdd-summary-2026-02-17T21-09-58Z.json`
+
+Validation run:
+
+- `npm run test:e2e -- tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts`
+- Result: expected skipped tests in RED phase
+
+---
+
+## Validation (Step 5)
+
+Checklist status:
+
+- [x] Prerequisites satisfied (story + framework + policy gates)
+- [x] Test files created and organized by level (API/E2E)
+- [x] All generated tests are explicitly RED-phase (`test.skip`)
+- [x] Acceptance criteria mapped to scenarios and priorities
+- [x] Supporting factory + fixture scaffolding created
+- [x] ATDD checklist output generated at required path
+- [x] Temp artifacts persisted under `{test_artifacts}/atdd-temp`
+
+Open assumptions/risks:
+
+- Story acceptance criteria are high-level; concrete field and index names are locked as RED-phase contract assumptions.
+- Final migration names and endpoint payload schema may require minor adjustments during GREEN phase.
+
+---
+
+## Next Recommended Workflow
+
+- Continue with implementation workflow for Story 0.6.
+- After implementation, remove `test.skip()` and run green-phase verification.

--- a/_bmad-output/test-artifacts/atdd-temp/tea-atdd-api-tests-2026-02-17T21-09-58Z.json
+++ b/_bmad-output/test-artifacts/atdd-temp/tea-atdd-api-tests-2026-02-17T21-09-58Z.json
@@ -1,0 +1,32 @@
+{
+  "success": true,
+  "subprocess": "atdd-api-tests",
+  "tests": [
+    {
+      "file": "tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts",
+      "description": "ATDD API tests for Story 0.6 platform events/outbox schema foundations (RED PHASE)",
+      "expected_to_fail": true,
+      "acceptance_criteria_covered": [
+        "events and outbox tables exist with required lineage and delivery fields",
+        "indexes support operational and replay queries"
+      ],
+      "priority_coverage": {
+        "P0": 2,
+        "P1": 2,
+        "P2": 0,
+        "P3": 0
+      }
+    }
+  ],
+  "fixture_needs": [
+    "platformEventOutbox.fixture.ts"
+  ],
+  "knowledge_fragments_used": [
+    "api-request",
+    "data-factories",
+    "api-testing-patterns"
+  ],
+  "test_count": 4,
+  "tdd_phase": "RED",
+  "summary": "Generated 4 FAILING API tests for Story 0.6 platform events/outbox schema contracts"
+}

--- a/_bmad-output/test-artifacts/atdd-temp/tea-atdd-e2e-tests-2026-02-17T21-09-58Z.json
+++ b/_bmad-output/test-artifacts/atdd-temp/tea-atdd-e2e-tests-2026-02-17T21-09-58Z.json
@@ -1,0 +1,32 @@
+{
+  "success": true,
+  "subprocess": "atdd-e2e-tests",
+  "tests": [
+    {
+      "file": "tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts",
+      "description": "ATDD E2E tests for Story 0.6 platform events/outbox schema journeys (RED PHASE)",
+      "expected_to_fail": true,
+      "acceptance_criteria_covered": [
+        "events and outbox tables exist with required lineage and delivery fields",
+        "indexes support operational and replay queries"
+      ],
+      "priority_coverage": {
+        "P0": 1,
+        "P1": 2,
+        "P2": 0,
+        "P3": 0
+      }
+    }
+  ],
+  "fixture_needs": [
+    "platformEventOutbox.fixture.ts"
+  ],
+  "knowledge_fragments_used": [
+    "fixture-architecture",
+    "network-first",
+    "selector-resilience"
+  ],
+  "test_count": 3,
+  "tdd_phase": "RED",
+  "summary": "Generated 3 FAILING E2E tests for Story 0.6 platform schema/index journeys"
+}

--- a/_bmad-output/test-artifacts/atdd-temp/tea-atdd-summary-2026-02-17T21-09-58Z.json
+++ b/_bmad-output/test-artifacts/atdd-temp/tea-atdd-summary-2026-02-17T21-09-58Z.json
@@ -1,0 +1,35 @@
+{
+  "tdd_phase": "RED",
+  "story_id": "0-6",
+  "total_tests": 7,
+  "api_tests": 4,
+  "e2e_tests": 3,
+  "all_tests_skipped": true,
+  "expected_to_fail": true,
+  "fixtures_created": 1,
+  "acceptance_criteria_covered": [
+    "events and outbox tables exist with required lineage and delivery fields",
+    "indexes support operational and replay queries"
+  ],
+  "knowledge_fragments_used": [
+    "data-factories",
+    "component-tdd",
+    "test-quality",
+    "test-healing-patterns",
+    "selector-resilience",
+    "timing-debugging",
+    "overview",
+    "api-request",
+    "network-recorder",
+    "auth-session",
+    "intercept-network-call",
+    "recurse",
+    "log",
+    "file-utils",
+    "network-error-monitor",
+    "fixtures-composition",
+    "playwright-cli"
+  ],
+  "subprocess_execution": "PARALLEL (API + E2E)",
+  "performance_gain": "~50% faster than sequential"
+}

--- a/_bmad-output/test-artifacts/automation-summary.md
+++ b/_bmad-output/test-artifacts/automation-summary.md
@@ -6,81 +6,111 @@ stepsCompleted:
   - step-03c-aggregate
   - step-04-validate-and-summarize
 lastStep: step-04-validate-and-summarize
-lastSaved: 2026-02-17T19:52:18Z
+lastSaved: 2026-02-17T21:16:37Z
+storyId: '0-6'
+storyFile: '/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md'
+subprocessTimestamp: '2026-02-17T21-16-37Z'
+executionMode: 'BMad-Integrated'
 ---
 
-# Test Automation Summary - Story 0.5
+# Test Automation Summary - Story 0.6
 
 ## Step 1 - Preflight and Context
 - Mode: BMad-Integrated
-- Input artifact: `_bmad-output/implementation-artifacts/0-5-shared-api-envelope-and-business-refusal-contract.md`
-- Framework readiness: `playwright.config.ts` present and `@playwright/test` installed in `package.json`
-- Existing test structure detected under `tests/` with `api`, `e2e`, `support/fixtures`, and `support/factories`
-- TEA flags loaded from `_bmad/tea/config.yaml`:
+- Input artifacts loaded:
+  - `_bmad-output/implementation-artifacts/0-6-platform-events-and-outbox-schema-foundations.md`
+  - `_bmad-output/test-artifacts/atdd-checklist-0-6.md`
+- Framework readiness:
+  - `playwright.config.ts` exists
+  - `@playwright/test` present in `package.json`
+  - test structure present under `tests/`
+- TEA config flags:
   - `tea_use_playwright_utils=true`
   - `tea_browser_automation=auto`
-- Browser exploration: `playwright-cli` not installed, so discovery used code + artifact analysis fallback
+- Story implementation status discovered:
+  - `src/src/routes/api/v1/platform-contracts.ts` does **not** yet implement Story 0.6 contract endpoints:
+    - `GET /api/v1/platform/_kernel/contracts/events/schema`
+    - `GET /api/v1/platform/_kernel/contracts/outbox/schema`
+    - `GET /api/v1/platform/_kernel/contracts/events-outbox/indexes`
+    - `GET /api/v1/platform/_kernel/contracts/outbox/replay-query`
+
+Knowledge fragments loaded:
+- Core: `test-levels`, `test-priorities`, `data-factories`, `selective-testing`, `ci-burn-in`, `test-quality`
+- Playwright utils + automation: `overview`, `api-request`, `network-recorder`, `auth-session`, `intercept-network-call`, `recurse`, `log`, `file-utils`, `burn-in`, `network-error-monitor`, `fixtures-composition`, `playwright-cli`
+- Additional for current target: `api-testing-patterns`, `selector-resilience`
 
 ## Step 2 - Coverage Plan
-- Scope basis: Story AC1 and AC2
-- Coverage target: `critical-paths`
+Coverage target: `critical-paths`
 
 ### API targets
-- `POST /api/v1/platform/_kernel/contracts/envelope/success`
-  - P0: canonical shared envelope helper contract shape (`ok=true`, `code`, `message`, `correlationId`, `tenantId`)
-- `POST /api/v1/platform/_kernel/contracts/envelope/business-refusal`
-  - P0: business refusal contract with HTTP 200 and `ok=false`
-  - P1: deterministic refusal content and no internal stack leakage
-- Cross-endpoint consistency
-  - P1: required top-level keys consistent between success and refusal envelopes
+- P0:
+  - canonical `platform.events` lineage schema contract
+  - canonical `platform.outbox_events` delivery schema contract
+- P1:
+  - operational/replay index metadata contract
+  - replay-query cursor semantics contract
+  - tenant/correlation metadata continuity across schema/index/replay endpoints
+- P2:
+  - deterministic, duplicate-free index set contract for operator adapters
 
 ### E2E targets
-- P0: journey-level verification of business refusal semantics (HTTP 200 + `ok=false`)
-- P1: correlation-id consistency across success/refusal flows
-- P1: structured refusal fields stable for downstream UI adapters
+- P0:
+  - combined schema journey across events and outbox endpoints
+- P1:
+  - correlation metadata stability across schema/index endpoints
+  - replay-ready outbox index hints for adapter consumers
+  - replay-query cursor semantics alignment with outbox index hints
+
+### Duplicate-coverage handling
+- Reused existing Story 0.6 ATDD files and expanded them in-place to avoid duplicate specs.
 
 ## Step 3 - Parallel Generation + Aggregation
-- Subprocess outputs generated:
-  - `/tmp/tea-automate-api-tests-2026-02-17T19-52-18-200Z.json`
-  - `/tmp/tea-automate-e2e-tests-2026-02-17T19-52-18-200Z.json`
-- Aggregated summary generated:
-  - `/tmp/tea-automate-summary-2026-02-17T19-52-18-200Z.json`
+Subprocess outputs:
+- `/tmp/tea-automate-api-tests-2026-02-17T21-16-37Z.json`
+- `/tmp/tea-automate-e2e-tests-2026-02-17T21-16-37Z.json`
 
-### Files updated
-- `tests/api/platform/shared-api-envelope-and-business-refusal-contract.api.spec.ts`
-  - Enabled 4 tests (removed `test.skip`)
-- `tests/e2e/platform/shared-api-envelope-and-business-refusal-contract.spec.ts`
-  - Enabled 3 tests (removed `test.skip`)
+Aggregate summary:
+- `/tmp/tea-automate-summary-2026-02-17T21-16-37Z.json`
 
-### Fixture infrastructure
-- Reused existing shared fixture/factory stack (no additional scaffold required):
-  - `tests/support/fixtures/sharedApiEnvelope.fixture.ts`
-  - `tests/support/factories/sharedApiEnvelopeFactory.ts`
+Files updated:
+- `tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts`
+  - expanded from 4 to 6 API tests
+- `tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts`
+  - expanded from 3 to 4 E2E tests
+
+Fixture infrastructure:
+- Reused existing support stack (no new scaffolding required):
+  - `tests/support/factories/platformEventOutboxFactory.ts`
+  - `tests/support/fixtures/platformEventOutbox.fixture.ts`
   - `tests/support/helpers/apiClient.ts`
 
-### Aggregated totals
-- Total tests: 7
-  - API: 4
-  - E2E: 3
+Aggregated totals:
+- Total tests: 10
+  - API: 6
+  - E2E: 4
 - Priority coverage:
   - P0: 3
-  - P1: 4
-  - P2: 0
+  - P1: 6
+  - P2: 1
   - P3: 0
 
 ## Step 4 - Validation
-Checklist alignment:
+Checklist outcome:
 - Framework readiness: pass
-- Coverage mapping: pass (AC1 + AC2 explicitly covered)
+- Coverage mapping to Story 0.6 ACs: pass
 - Test quality structure: pass (priority tags, deterministic assertions, no hard waits)
-- Fixtures/factories/helpers: pass (existing reusable support layer)
-- CLI session cleanup: pass (CLI not used)
+- Fixtures/factories/helpers: pass (reused existing architecture)
+- CLI sessions cleaned: pass (no CLI browser sessions opened)
 - Temp artifacts location: pass (`/tmp` and `_bmad-output/test-artifacts`)
 
-## Assumptions and Risks
-- Assumption: Story 0.5 implementation and route registration for `_kernel/contracts/envelope/*` exist or will be landed before CI gate runs.
-- Risk: If endpoints are not implemented yet, newly enabled tests will fail as intended and should be treated as implementation gap signal.
+Execution validation:
+- `npm run test:e2e -- --list tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts`
+- Result: 10 tests discovered successfully in 2 files
+
+Assumptions and risks:
+- Story 0.6 backend contract endpoints are not implemented yet; all Story 0.6 tests remain intentionally `test.skip(...)`.
+- Green-phase activation requires implementing the four Story 0.6 contract endpoints and then removing `test.skip` incrementally (P0 before P1/P2).
 
 ## Recommended Next Workflow
-- `RV` (Review Tests): run TEA test review for robustness scoring and anti-pattern scan.
-- `TR` (Trace Requirements): map Story 0.5 acceptance criteria to these 7 tests for gate decision.
+- `RV` (Review Tests): quality scorecard and anti-pattern scan.
+- `TR` (Trace Requirements): map Story 0.6 ACs to these 10 tests and gate readiness.

--- a/src/src/migrations/20260217113000_create_platform_events_and_outbox.ts
+++ b/src/src/migrations/20260217113000_create_platform_events_and_outbox.ts
@@ -1,0 +1,58 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw('CREATE SCHEMA IF NOT EXISTS platform');
+
+  await knex.schema.withSchema('platform').createTable('events', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('tenant_id').notNullable().references('id').inTable('households').onDelete('CASCADE');
+    table.uuid('actor_id').references('id').inTable('users').onDelete('SET NULL');
+    table.string('event_name', 150).notNullable();
+    table.string('entity_type', 100).notNullable();
+    table.uuid('entity_id').notNullable();
+    table.timestamp('occurred_at_utc').notNullable().defaultTo(knex.fn.now());
+    table.jsonb('payload').notNullable().defaultTo('{}');
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+
+    table.index(['tenant_id', 'occurred_at_utc']);
+    table.index(['entity_type', 'entity_id', 'occurred_at_utc']);
+    table.index(['event_name', 'occurred_at_utc']);
+  });
+
+  await knex.schema.withSchema('platform').createTable('outbox_events', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table
+      .uuid('event_id')
+      .notNullable()
+      .unique()
+      .references('id')
+      .inTable('platform.events')
+      .onDelete('CASCADE');
+
+    table.uuid('tenant_id').notNullable().references('id').inTable('households').onDelete('CASCADE');
+    table.string('event_name', 150).notNullable();
+    table.string('entity_type', 100).notNullable();
+    table.uuid('entity_id').notNullable();
+    table.timestamp('occurred_at_utc').notNullable();
+    table.jsonb('payload').notNullable().defaultTo('{}');
+
+    table.string('delivery_status', 30).notNullable().defaultTo('pending');
+    table.integer('delivery_attempts').notNullable().defaultTo(0);
+    table.timestamp('available_at_utc').notNullable().defaultTo(knex.fn.now());
+    table.timestamp('leased_until_utc');
+    table.timestamp('delivered_at_utc');
+    table.text('last_delivery_error');
+
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+
+    table.index(['delivery_status', 'available_at_utc']);
+    table.index(['tenant_id', 'delivery_status', 'available_at_utc']);
+    table.index(['event_name', 'occurred_at_utc']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.withSchema('platform').dropTableIfExists('outbox_events');
+  await knex.schema.withSchema('platform').dropTableIfExists('events');
+}

--- a/src/src/migrations/20260217113000_create_platform_events_and_outbox.ts
+++ b/src/src/migrations/20260217113000_create_platform_events_and_outbox.ts
@@ -48,11 +48,43 @@ export async function up(knex: Knex): Promise<void> {
 
     table.index(['delivery_status', 'available_at_utc']);
     table.index(['tenant_id', 'delivery_status', 'available_at_utc']);
+    table.index(['delivery_status', 'available_at_utc', 'leased_until_utc']);
     table.index(['event_name', 'occurred_at_utc']);
   });
+
+  await knex.raw(`
+    ALTER TABLE platform.outbox_events
+    ADD CONSTRAINT outbox_events_delivery_status_chk
+    CHECK (delivery_status IN ('pending', 'leased', 'delivered', 'failed'))
+  `);
+
+  await knex.raw(`
+    ALTER TABLE platform.outbox_events
+    ADD CONSTRAINT outbox_events_delivery_attempts_nonnegative_chk
+    CHECK (delivery_attempts >= 0)
+  `);
+
+  await knex.raw(`
+    CREATE OR REPLACE FUNCTION platform.set_outbox_events_updated_at()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      NEW.updated_at = NOW();
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+
+  await knex.raw(`
+    CREATE TRIGGER trg_outbox_events_set_updated_at
+    BEFORE UPDATE ON platform.outbox_events
+    FOR EACH ROW
+    EXECUTE FUNCTION platform.set_outbox_events_updated_at()
+  `);
 }
 
 export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP TRIGGER IF EXISTS trg_outbox_events_set_updated_at ON platform.outbox_events');
+  await knex.raw('DROP FUNCTION IF EXISTS platform.set_outbox_events_updated_at()');
   await knex.schema.withSchema('platform').dropTableIfExists('outbox_events');
   await knex.schema.withSchema('platform').dropTableIfExists('events');
 }

--- a/src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts
+++ b/src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts
@@ -1,0 +1,190 @@
+import { down, up } from '../20260217113000_create_platform_events_and_outbox';
+
+type ColumnRecord = {
+  type: string;
+  args: any[];
+  chain: {
+    notNullable: boolean;
+    defaultValue: any;
+    references?: string;
+    inTable?: string;
+    onDelete?: string;
+    isUnique: boolean;
+    isPrimary: boolean;
+  };
+};
+
+type TableRecord = {
+  columns: Record<string, ColumnRecord>;
+  indexes: Array<{ columns: string[]; indexName?: string }>;
+};
+
+function buildKnexMock() {
+  const tables = new Map<string, TableRecord>();
+  const dropped: string[] = [];
+
+  const createTable = (fullTableName: string, callback: (table: any) => void) => {
+    const record: TableRecord = { columns: {}, indexes: [] };
+
+    const makeColumn = (columnName: string, type: string, args: any[]) => {
+      const chainState = {
+        notNullable: false,
+        defaultValue: undefined,
+        references: undefined as string | undefined,
+        inTable: undefined as string | undefined,
+        onDelete: undefined as string | undefined,
+        isUnique: false,
+        isPrimary: false,
+      };
+
+      const chain = {
+        notNullable() {
+          chainState.notNullable = true;
+          return chain;
+        },
+        defaultTo(value: any) {
+          chainState.defaultValue = value;
+          return chain;
+        },
+        references(column: string) {
+          chainState.references = column;
+          return chain;
+        },
+        inTable(tableName: string) {
+          chainState.inTable = tableName;
+          return chain;
+        },
+        onDelete(action: string) {
+          chainState.onDelete = action;
+          return chain;
+        },
+        unique() {
+          chainState.isUnique = true;
+          return chain;
+        },
+        primary() {
+          chainState.isPrimary = true;
+          return chain;
+        },
+      };
+
+      record.columns[columnName] = {
+        type,
+        args,
+        chain: chainState,
+      };
+
+      return chain;
+    };
+
+    const table = {
+      uuid: (name: string) => makeColumn(name, 'uuid', []),
+      string: (name: string, ...args: any[]) => makeColumn(name, 'string', args),
+      integer: (name: string) => makeColumn(name, 'integer', []),
+      timestamp: (name: string, ...args: any[]) => makeColumn(name, 'timestamp', args),
+      jsonb: (name: string) => makeColumn(name, 'jsonb', []),
+      text: (name: string) => makeColumn(name, 'text', []),
+      index: (columns: string[] | string, indexName?: string) => {
+        record.indexes.push({
+          columns: Array.isArray(columns) ? columns : [columns],
+          indexName,
+        });
+      },
+      unique: (columns: string[] | string) => {
+        const key = Array.isArray(columns) ? columns.join('_') : columns;
+        makeColumn(`__unique__${key}`, 'unique', [columns]);
+      },
+    };
+
+    callback(table);
+    tables.set(fullTableName, record);
+  };
+
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+    fn: {
+      now: () => 'NOW()',
+    },
+    schema: {
+      withSchema: (schemaName: string) => ({
+        createTable: async (tableName: string, callback: (table: any) => void) => {
+          createTable(`${schemaName}.${tableName}`, callback);
+        },
+        dropTableIfExists: async (tableName: string) => {
+          dropped.push(`${schemaName}.${tableName}`);
+        },
+      }),
+    },
+  };
+
+  return { knex, tables, dropped };
+}
+
+describe('20260217113000_create_platform_events_and_outbox migration', () => {
+  describe('AC1: create canonical platform events/outbox tables with lineage + delivery fields', () => {
+    it('creates platform.events and platform.outbox_events with required fields', async () => {
+      const { knex, tables } = buildKnexMock();
+
+      await up(knex);
+
+      expect(knex.raw).toHaveBeenCalledWith('CREATE SCHEMA IF NOT EXISTS platform');
+      expect(tables.has('platform.events')).toBe(true);
+      expect(tables.has('platform.outbox_events')).toBe(true);
+
+      const events = tables.get('platform.events')!;
+      const outbox = tables.get('platform.outbox_events')!;
+
+      expect(events.columns.event_name).toBeDefined();
+      expect(events.columns.tenant_id).toBeDefined();
+      expect(events.columns.actor_id).toBeDefined();
+      expect(events.columns.entity_type).toBeDefined();
+      expect(events.columns.entity_id).toBeDefined();
+      expect(events.columns.occurred_at_utc).toBeDefined();
+      expect(events.columns.payload).toBeDefined();
+
+      expect(outbox.columns.delivery_status).toBeDefined();
+      expect(outbox.columns.delivery_attempts).toBeDefined();
+      expect(outbox.columns.available_at_utc).toBeDefined();
+      expect(outbox.columns.delivered_at_utc).toBeDefined();
+      expect(outbox.columns.last_delivery_error).toBeDefined();
+
+      expect(outbox.columns.event_id).toBeDefined();
+      expect(outbox.columns.tenant_id).toBeDefined();
+      expect(outbox.columns.event_name).toBeDefined();
+      expect(outbox.columns.entity_type).toBeDefined();
+      expect(outbox.columns.entity_id).toBeDefined();
+      expect(outbox.columns.occurred_at_utc).toBeDefined();
+      expect(outbox.columns.payload).toBeDefined();
+    });
+  });
+
+  describe('AC2: add operational and replay indexes', () => {
+    it('creates indexes for polling, replay, and lineage retrieval', async () => {
+      const { knex, tables, dropped } = buildKnexMock();
+
+      await up(knex);
+
+      const events = tables.get('platform.events')!;
+      const outbox = tables.get('platform.outbox_events')!;
+
+      expect(events.indexes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ columns: ['tenant_id', 'occurred_at_utc'] }),
+          expect.objectContaining({ columns: ['entity_type', 'entity_id', 'occurred_at_utc'] }),
+          expect.objectContaining({ columns: ['event_name', 'occurred_at_utc'] }),
+        ])
+      );
+
+      expect(outbox.indexes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ columns: ['delivery_status', 'available_at_utc'] }),
+          expect.objectContaining({ columns: ['tenant_id', 'delivery_status', 'available_at_utc'] }),
+          expect.objectContaining({ columns: ['event_name', 'occurred_at_utc'] }),
+        ])
+      );
+
+      await down(knex);
+      expect(dropped).toEqual(['platform.outbox_events', 'platform.events']);
+    });
+  });
+});

--- a/src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts
+++ b/src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts
@@ -149,12 +149,36 @@ describe('20260217113000_create_platform_events_and_outbox migration', () => {
       expect(outbox.columns.last_delivery_error).toBeDefined();
 
       expect(outbox.columns.event_id).toBeDefined();
+      expect(outbox.columns.event_id.chain.notNullable).toBe(true);
+      expect(outbox.columns.event_id.chain.isUnique).toBe(true);
+      expect(outbox.columns.event_id.chain.references).toBe('id');
+      expect(outbox.columns.event_id.chain.inTable).toBe('platform.events');
+      expect(outbox.columns.event_id.chain.onDelete).toBe('CASCADE');
       expect(outbox.columns.tenant_id).toBeDefined();
+      expect(outbox.columns.tenant_id.chain.notNullable).toBe(true);
+      expect(outbox.columns.tenant_id.chain.references).toBe('id');
+      expect(outbox.columns.tenant_id.chain.inTable).toBe('households');
+      expect(outbox.columns.tenant_id.chain.onDelete).toBe('CASCADE');
       expect(outbox.columns.event_name).toBeDefined();
       expect(outbox.columns.entity_type).toBeDefined();
       expect(outbox.columns.entity_id).toBeDefined();
       expect(outbox.columns.occurred_at_utc).toBeDefined();
       expect(outbox.columns.payload).toBeDefined();
+
+      expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('outbox_events_delivery_status_chk'));
+      expect(knex.raw).toHaveBeenCalledWith(
+        expect.stringContaining("CHECK (delivery_status IN ('pending', 'leased', 'delivered', 'failed'))")
+      );
+      expect(knex.raw).toHaveBeenCalledWith(
+        expect.stringContaining('outbox_events_delivery_attempts_nonnegative_chk')
+      );
+      expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('CHECK (delivery_attempts >= 0)'));
+      expect(knex.raw).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE OR REPLACE FUNCTION platform.set_outbox_events_updated_at()')
+      );
+      expect(knex.raw).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TRIGGER trg_outbox_events_set_updated_at')
+      );
     });
   });
 
@@ -179,12 +203,17 @@ describe('20260217113000_create_platform_events_and_outbox migration', () => {
         expect.arrayContaining([
           expect.objectContaining({ columns: ['delivery_status', 'available_at_utc'] }),
           expect.objectContaining({ columns: ['tenant_id', 'delivery_status', 'available_at_utc'] }),
+          expect.objectContaining({ columns: ['delivery_status', 'available_at_utc', 'leased_until_utc'] }),
           expect.objectContaining({ columns: ['event_name', 'occurred_at_utc'] }),
         ])
       );
 
       await down(knex);
       expect(dropped).toEqual(['platform.outbox_events', 'platform.events']);
+      expect(knex.raw).toHaveBeenCalledWith(
+        'DROP TRIGGER IF EXISTS trg_outbox_events_set_updated_at ON platform.outbox_events'
+      );
+      expect(knex.raw).toHaveBeenCalledWith('DROP FUNCTION IF EXISTS platform.set_outbox_events_updated_at()');
     });
   });
 });

--- a/tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts
+++ b/tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts
@@ -60,7 +60,9 @@ test.describe('Story 0.6 atdd - platform events and outbox schema foundations AP
     });
   });
 
-  test.skip('returns operational and replay index contract metadata for events/outbox @P1', async ({
+  test.skip(
+    'returns operational and replay index contract metadata for events/outbox @P1',
+    async ({
     request,
   }) => {
     // Given required index expectations for operational and replay queries
@@ -86,7 +88,9 @@ test.describe('Story 0.6 atdd - platform events and outbox schema foundations AP
     });
   });
 
-  test.skip('exposes replay cursor semantics for pending outbox delivery queries @P1', async ({
+  test.skip(
+    'exposes replay cursor semantics for pending outbox delivery queries @P1',
+    async ({
     request,
   }) => {
     // Given a replay query contract requiring status + available_at cursor semantics
@@ -111,4 +115,78 @@ test.describe('Story 0.6 atdd - platform events and outbox schema foundations AP
       defaultOrder: ['available_at ASC', 'outbox_event_id ASC'],
     });
   });
+
+  test.skip(
+    'keeps tenant/correlation metadata stable across schema and replay endpoints @P1',
+    async ({ request }) => {
+      // Given one request context used across all contract endpoints
+      const headers = createPlatformContractHeaders({
+        tenantId: 'tenant-platform-correlation',
+        correlationId: 'corr-platform-correlation',
+      });
+
+      // When schema/index/replay contracts are requested
+      const eventsSchemaResponse = await apiRequest(request, {
+        method: 'GET',
+        path: '/api/v1/platform/_kernel/contracts/events/schema',
+        headers,
+      });
+      const indexesResponse = await apiRequest(request, {
+        method: 'GET',
+        path: '/api/v1/platform/_kernel/contracts/events-outbox/indexes',
+        headers,
+      });
+      const replayResponse = await apiRequest(request, {
+        method: 'GET',
+        path: '/api/v1/platform/_kernel/contracts/outbox/replay-query',
+        headers,
+      });
+
+      // Then each response should echo the same tenancy + correlation context
+      expect(eventsSchemaResponse.status()).toBe(200);
+      expect(indexesResponse.status()).toBe(200);
+      expect(replayResponse.status()).toBe(200);
+
+      const eventsBody = await eventsSchemaResponse.json();
+      const indexesBody = await indexesResponse.json();
+      const replayBody = await replayResponse.json();
+
+      expect(eventsBody.tenantId).toBe(headers['x-tenant-id']);
+      expect(eventsBody.correlationId).toBe(headers['x-correlation-id']);
+      expect(indexesBody.tenantId).toBe(headers['x-tenant-id']);
+      expect(indexesBody.correlationId).toBe(headers['x-correlation-id']);
+      expect(replayBody.tenantId).toBe(headers['x-tenant-id']);
+      expect(replayBody.correlationId).toBe(headers['x-correlation-id']);
+    },
+  );
+
+  test.skip(
+    'publishes deterministic index sets without duplicates for operator adapters @P2',
+    async ({ request }) => {
+      // Given expected operational/replay index names
+      const headers = createPlatformContractHeaders({
+        tenantId: 'tenant-platform-index-determinism',
+        correlationId: 'corr-platform-index-determinism',
+      });
+      const indexExpectations = createOperationalIndexExpectations();
+
+      // When the index contract endpoint is called
+      const response = await apiRequest(request, {
+        method: 'GET',
+        path: '/api/v1/platform/_kernel/contracts/events-outbox/indexes',
+        headers,
+      });
+
+      // Then index arrays should be deterministic and duplicate-free
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      expect(body.events).toEqual(indexExpectations.eventsIndexes);
+      expect(body.outbox).toEqual(indexExpectations.outboxIndexes);
+      expect(new Set(body.events).size).toBe(body.events.length);
+      expect(new Set(body.outbox).size).toBe(body.outbox.length);
+      expect(body.events.every((idx: string) => idx.endsWith('_idx'))).toBe(true);
+      expect(body.outbox.every((idx: string) => idx.endsWith('_idx'))).toBe(true);
+    },
+  );
 });

--- a/tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts
+++ b/tests/api/platform/platform-events-and-outbox-schema-foundations.api.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest } from '../../support/helpers/apiClient';
+import {
+  createEventSchemaExpectation,
+  createOperationalIndexExpectations,
+  createOutboxSchemaExpectation,
+  createPlatformContractHeaders,
+} from '../../support/factories/platformEventOutboxFactory';
+
+test.describe('Story 0.6 atdd - platform events and outbox schema foundations API coverage', () => {
+  test.skip('returns canonical platform.events lineage schema contract @P0', async ({
+    request,
+  }) => {
+    // Given platform lineage schema expectations for canonical event storage
+    const headers = createPlatformContractHeaders({
+      tenantId: 'tenant-platform-events-schema',
+      correlationId: 'corr-platform-events-schema',
+    });
+    const eventSchemaExpectation = createEventSchemaExpectation();
+
+    // When the events schema contract endpoint is called
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/events/schema',
+      headers,
+    });
+
+    // Then the response should expose required lineage fields
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      table: eventSchemaExpectation.tableName,
+      requiredLineageFields: eventSchemaExpectation.requiredLineageFields,
+    });
+  });
+
+  test.skip('returns canonical platform.outbox_events delivery schema contract @P0', async ({
+    request,
+  }) => {
+    // Given outbox delivery schema expectations for integration-safe replay
+    const headers = createPlatformContractHeaders({
+      tenantId: 'tenant-platform-outbox-schema',
+      correlationId: 'corr-platform-outbox-schema',
+    });
+    const outboxSchemaExpectation = createOutboxSchemaExpectation();
+
+    // When the outbox schema contract endpoint is called
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/outbox/schema',
+      headers,
+    });
+
+    // Then the response should expose required delivery and lineage fields
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      table: outboxSchemaExpectation.tableName,
+      requiredDeliveryFields: outboxSchemaExpectation.requiredDeliveryFields,
+    });
+  });
+
+  test.skip('returns operational and replay index contract metadata for events/outbox @P1', async ({
+    request,
+  }) => {
+    // Given required index expectations for operational and replay queries
+    const headers = createPlatformContractHeaders({
+      tenantId: 'tenant-platform-indexes',
+      correlationId: 'corr-platform-indexes',
+    });
+    const indexExpectations = createOperationalIndexExpectations();
+
+    // When the index contract endpoint is called
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/events-outbox/indexes',
+      headers,
+    });
+
+    // Then index definitions should include canonical operational and replay index names
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      events: indexExpectations.eventsIndexes,
+      outbox: indexExpectations.outboxIndexes,
+    });
+  });
+
+  test.skip('exposes replay cursor semantics for pending outbox delivery queries @P1', async ({
+    request,
+  }) => {
+    // Given a replay query contract requiring status + available_at cursor semantics
+    const headers = createPlatformContractHeaders({
+      tenantId: 'tenant-platform-replay',
+      correlationId: 'corr-platform-replay',
+    });
+
+    // When the replay contract endpoint is called
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/outbox/replay-query',
+      headers,
+    });
+
+    // Then replay contract metadata should expose deterministic pagination/query keys
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      table: 'platform.outbox_events',
+      queryKeys: ['delivery_status', 'available_at', 'outbox_event_id'],
+      defaultOrder: ['available_at ASC', 'outbox_event_id ASC'],
+    });
+  });
+});

--- a/tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts
+++ b/tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts
@@ -1,0 +1,83 @@
+import { apiRequest } from '../../support/helpers/apiClient';
+import { test, expect } from '../../support/fixtures/platformEventOutbox.fixture';
+
+test.describe('Story 0.6 atdd - platform events and outbox schema foundations journey', () => {
+  test.skip('returns schema contracts for events and outbox in one integration-safe journey @P0', async ({
+    request,
+    platformContractHeaders,
+    eventSchemaExpectation,
+    outboxSchemaExpectation,
+  }) => {
+    // Given a single integration context for schema contract discovery
+    const eventsResponse = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/events/schema',
+      headers: platformContractHeaders,
+    });
+    const outboxResponse = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/outbox/schema',
+      headers: platformContractHeaders,
+    });
+
+    // Then both canonical schema contracts should be published
+    expect(eventsResponse.status()).toBe(200);
+    expect(outboxResponse.status()).toBe(200);
+
+    const eventsBody = await eventsResponse.json();
+    const outboxBody = await outboxResponse.json();
+
+    expect(eventsBody).toMatchObject({
+      table: eventSchemaExpectation.tableName,
+    });
+    expect(outboxBody).toMatchObject({
+      table: outboxSchemaExpectation.tableName,
+    });
+  });
+
+  test.skip('keeps correlation metadata stable across schema and index contract endpoints @P1', async ({
+    request,
+    platformContractHeaders,
+  }) => {
+    // Given one correlation id across schema and index requests
+    const eventsSchemaResponse = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/events/schema',
+      headers: platformContractHeaders,
+    });
+    const indexesResponse = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/events-outbox/indexes',
+      headers: platformContractHeaders,
+    });
+
+    // Then all contract responses should preserve caller correlation id
+    expect(eventsSchemaResponse.status()).toBe(200);
+    expect(indexesResponse.status()).toBe(200);
+
+    const schemaBody = await eventsSchemaResponse.json();
+    const indexesBody = await indexesResponse.json();
+    const correlationId = platformContractHeaders['x-correlation-id'];
+
+    expect(schemaBody.correlationId).toBe(correlationId);
+    expect(indexesBody.correlationId).toBe(correlationId);
+  });
+
+  test.skip('exposes replay-ready outbox index hints for operator tooling adapters @P1', async ({
+    request,
+    platformContractHeaders,
+    operationalIndexExpectations,
+  }) => {
+    // Given an operator adapter requesting replay index contract metadata
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/events-outbox/indexes',
+      headers: platformContractHeaders,
+    });
+
+    // Then outbox replay indexes should be explicit and deterministic
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.outbox).toEqual(operationalIndexExpectations.outboxIndexes);
+  });
+});

--- a/tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts
+++ b/tests/e2e/platform/platform-events-and-outbox-schema-foundations.spec.ts
@@ -80,4 +80,40 @@ test.describe('Story 0.6 atdd - platform events and outbox schema foundations jo
     const body = await response.json();
     expect(body.outbox).toEqual(operationalIndexExpectations.outboxIndexes);
   });
+
+  test.skip('aligns replay-query cursor semantics with published outbox index hints @P1', async ({
+    request,
+    platformContractHeaders,
+    operationalIndexExpectations,
+  }) => {
+    // Given one operator context consuming both indexes and replay query metadata
+    const indexesResponse = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/events-outbox/indexes',
+      headers: platformContractHeaders,
+    });
+    const replayQueryResponse = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/_kernel/contracts/outbox/replay-query',
+      headers: platformContractHeaders,
+    });
+
+    // Then replay cursor keys should align with replay-oriented outbox indexes
+    expect(indexesResponse.status()).toBe(200);
+    expect(replayQueryResponse.status()).toBe(200);
+
+    const indexesBody = await indexesResponse.json();
+    const replayBody = await replayQueryResponse.json();
+
+    expect(indexesBody.outbox).toEqual(operationalIndexExpectations.outboxIndexes);
+    expect(replayBody.queryKeys).toEqual([
+      'delivery_status',
+      'available_at',
+      'outbox_event_id',
+    ]);
+    expect(replayBody.defaultOrder).toEqual([
+      'available_at ASC',
+      'outbox_event_id ASC',
+    ]);
+  });
 });

--- a/tests/support/factories/platformEventOutboxFactory.ts
+++ b/tests/support/factories/platformEventOutboxFactory.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto';
+
+type PlatformContractHeaderOverrides = {
+  tenantId?: string;
+  correlationId?: string;
+  csrfToken?: string;
+};
+
+type EventSchemaExpectationOverrides = {
+  tableName?: string;
+};
+
+type OutboxSchemaExpectationOverrides = {
+  tableName?: string;
+};
+
+export function createPlatformContractHeaders(
+  overrides: PlatformContractHeaderOverrides = {},
+): Record<string, string> {
+  return {
+    'x-tenant-id': overrides.tenantId ?? `tenant-${randomUUID()}`,
+    'x-correlation-id': overrides.correlationId ?? `corr-${randomUUID()}`,
+    'x-csrf-token': overrides.csrfToken ?? `csrf-${randomUUID()}`,
+  };
+}
+
+export function createEventSchemaExpectation(
+  overrides: EventSchemaExpectationOverrides = {},
+) {
+  return {
+    tableName: overrides.tableName ?? 'platform.events',
+    requiredLineageFields: [
+      'event_id',
+      'tenant_id',
+      'aggregate_type',
+      'aggregate_id',
+      'event_type',
+      'event_version',
+      'occurred_at',
+      'created_at',
+      'payload',
+      'metadata',
+    ],
+  };
+}
+
+export function createOutboxSchemaExpectation(
+  overrides: OutboxSchemaExpectationOverrides = {},
+) {
+  return {
+    tableName: overrides.tableName ?? 'platform.outbox_events',
+    requiredDeliveryFields: [
+      'outbox_event_id',
+      'tenant_id',
+      'event_id',
+      'delivery_status',
+      'available_at',
+      'attempt_count',
+      'last_error',
+      'claimed_at',
+      'delivered_at',
+      'payload',
+      'headers',
+      'created_at',
+      'updated_at',
+    ],
+  };
+}
+
+export function createOperationalIndexExpectations() {
+  return {
+    eventsIndexes: [
+      'events_tenant_occurred_idx',
+      'events_aggregate_lookup_idx',
+    ],
+    outboxIndexes: [
+      'outbox_delivery_ready_idx',
+      'outbox_replay_cursor_idx',
+      'outbox_event_id_unique_idx',
+    ],
+  };
+}

--- a/tests/support/fixtures/platformEventOutbox.fixture.ts
+++ b/tests/support/fixtures/platformEventOutbox.fixture.ts
@@ -1,0 +1,33 @@
+import { test as base } from '@playwright/test';
+import {
+  createEventSchemaExpectation,
+  createOperationalIndexExpectations,
+  createOutboxSchemaExpectation,
+  createPlatformContractHeaders,
+} from '../factories/platformEventOutboxFactory';
+
+type PlatformEventOutboxFixtures = {
+  platformContractHeaders: ReturnType<typeof createPlatformContractHeaders>;
+  eventSchemaExpectation: ReturnType<typeof createEventSchemaExpectation>;
+  outboxSchemaExpectation: ReturnType<typeof createOutboxSchemaExpectation>;
+  operationalIndexExpectations: ReturnType<
+    typeof createOperationalIndexExpectations
+  >;
+};
+
+export const test = base.extend<PlatformEventOutboxFixtures>({
+  platformContractHeaders: async ({}, use) => {
+    await use(createPlatformContractHeaders());
+  },
+  eventSchemaExpectation: async ({}, use) => {
+    await use(createEventSchemaExpectation());
+  },
+  outboxSchemaExpectation: async ({}, use) => {
+    await use(createOutboxSchemaExpectation());
+  },
+  operationalIndexExpectations: async ({}, use) => {
+    await use(createOperationalIndexExpectations());
+  },
+});
+
+export { expect } from '@playwright/test';


### PR DESCRIPTION
## Summary\n- add DB-level outbox invariants for delivery status whitelist and non-negative delivery attempts\n- add lease-aware outbox polling index and trigger-based updated_at maintenance with rollback cleanup\n- expand migration tests to verify FK/unique semantics, constraints, and trigger lifecycle\n- update story 0.6 and sprint status to done after review remediation\n\n## Testing\n- cd src && npm test -- --runInBand src/src/migrations/__tests__/platformEventsOutboxMigration.test.ts\n- cd src && npm test -- --runInBand