### PR TITLE
Fix: resolve story 0.8 UTC/local rendering contract review findings

### DIFF
--- a/_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md
+++ b/_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md
@@ -56,6 +56,7 @@ GPT-5 Codex
   - `GET /api/v1/platform/operations/feed`
 - Added contract/integration tests in `src/src/__tests__/centralizedTimeServiceContract.test.ts`.
 - Added unit coverage in `src/src/platform/time/__tests__/timezoneService.test.ts`.
+- Applied review follow-up fixes: strict UTC ISO validation, render-contract UTC redaction, and operations-feed invalid-timestamp refusal handling.
 - Regression run: `cd src && npm test` (pass).
 
 ### Completion Notes List
@@ -65,7 +66,7 @@ GPT-5 Codex
 - Implemented operational feed payload contract that only returns localized display values (`occurredAtLocal`) and excludes raw UTC fields from UI-oriented rows.
 - Added automated AC coverage:
   - AC1 covered by fallback/resolve tests in `src/src/__tests__/centralizedTimeServiceContract.test.ts` and `src/src/platform/time/__tests__/timezoneService.test.ts`.
-  - AC2 covered by operations-feed contract assertion that raw UTC fields are omitted plus refusal-path coverage.
+  - AC2 covered by operations-feed and render-contract assertions that raw UTC fields are omitted plus refusal-path coverage for unresolved context and invalid timestamp input.
 - Full backend Jest suite passes after changes.
 
 ### Implementation Plan
@@ -82,8 +83,63 @@ GPT-5 Codex
 - `src/src/routes/api/v1/platform-contracts.ts`
 - `src/src/__tests__/centralizedTimeServiceContract.test.ts`
 - `_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md`
-- `_bmad-output/implementation-artifacts/sprint-status.yaml`
 
 ## Change Log
 
 - 2026-02-18: Implemented centralized timezone fallback/formatting service, added platform time endpoints and operational feed UTC-redaction contract behavior, and added automated AC1/AC2 backend coverage.
+- 2026-02-18: Senior Developer Review (AI) completed; status moved to in-progress due to unresolved HIGH/MEDIUM findings.
+- 2026-02-18: Resolved all 4 review findings (UTC redaction, strict UTC validation, invalid timestamp contract tests, and feed null-guard refusal path) and reconciled story/git tracking.
+
+## Senior Developer Review (AI)
+
+Reviewer: Jeremiah  
+Date: 2026-02-18  
+Outcome: Resolved
+
+### Scope Reviewed
+
+- `src/src/platform/time/timezoneService.ts`
+- `src/src/platform/time/__tests__/timezoneService.test.ts`
+- `src/src/routes/api/v1/platform-contracts.ts`
+- `src/src/__tests__/centralizedTimeServiceContract.test.ts`
+
+### Git vs Story
+
+- Story file list and git change set are aligned for this follow-up pass (5 files changed).
+- Review discrepancy from prior pass (clean tree with no code diff) is resolved by applied implementation and test updates.
+
+### Findings (Resolved)
+
+#### HIGH (Resolved)
+
+1. Raw UTC was returned from a platform response payload in this story scope:
+   - `src/src/routes/api/v1/platform-contracts.ts` included `utcTimestamp` in response data for `/time/render-contract`.
+   - This conflicts with the story contract intent that operational UI-facing payloads should not surface raw UTC.
+
+#### MEDIUM (Resolved)
+
+1. UTC contract was not actually enforced by parser logic:
+   - `src/src/platform/time/timezoneService.ts` parsed any `Date`-parseable string.
+   - `src/src/routes/api/v1/platform-contracts.ts` claimed strict UTC ISO-8601 validation, but non-UTC inputs could pass.
+
+2. Missing contract test for invalid timestamp refusal path on `/time/render-contract`:
+   - `src/src/__tests__/centralizedTimeServiceContract.test.ts` lacked a test covering `INVALID_UTC_TIMESTAMP`.
+   - Completion notes claim refusal-path coverage for invalid timestamp, but this specific path is not verified.
+
+3. Operations feed mapping could emit nullable localized values without refusal handling:
+   - `src/src/routes/api/v1/platform-contracts.ts` assigned formatter output directly.
+   - If a source timestamp is malformed, `occurredAtLocal` can become `null`, violating display contract expectations.
+
+### Resolution Update (2026-02-18)
+
+- Removed raw `utcTimestamp` from `/time/render-contract` success payload.
+- Enforced strict UTC ISO-8601 validation before formatting timestamps.
+- Added contract coverage for invalid `/time/render-contract` timestamp refusal path.
+- Hardened `/operations/feed` row mapping to refuse invalid UTC source rows instead of emitting nullable local timestamps.
+- Re-ran backend Jest suite after fixes.
+- No open HIGH or MEDIUM findings remain.
+
+### Validation Evidence
+
+- Backend test run executed: `cd src && npm test`
+- Result: 16 passed suites, 1 skipped; 62 passed tests, 2 skipped.

--- a/_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md
+++ b/_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md
@@ -1,6 +1,6 @@
 # Story 0.8: Centralized Time Service and UTC/Local Rendering Contract
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -17,10 +17,10 @@ so that users/admin always see local timezone while storage remains UTC..
 
 ## Tasks / Subtasks
 
-- [ ] Implement acceptance criterion 1 (AC: 1)
-  - [ ] Add automated coverage for AC 1
-- [ ] Implement acceptance criterion 2 (AC: 2)
-  - [ ] Add automated coverage for AC 2
+- [x] Implement acceptance criterion 1 (AC: 1)
+  - [x] Add automated coverage for AC 1
+- [x] Implement acceptance criterion 2 (AC: 2)
+  - [x] Add automated coverage for AC 2
 
 ## Dev Notes
 
@@ -49,12 +49,41 @@ GPT-5 Codex
 
 ### Debug Log References
 
--
+- Added centralized time resolution + UTC->local formatter in `src/src/platform/time/timezoneService.ts`.
+- Added platform contract endpoints in `src/src/routes/api/v1/platform-contracts.ts`:
+  - `GET /api/v1/platform/time/render-context`
+  - `POST /api/v1/platform/time/render-contract`
+  - `GET /api/v1/platform/operations/feed`
+- Added contract/integration tests in `src/src/__tests__/centralizedTimeServiceContract.test.ts`.
+- Added unit coverage in `src/src/platform/time/__tests__/timezoneService.test.ts`.
+- Regression run: `cd src && npm test` (pass).
 
 ### Completion Notes List
 
--
+- Enforced timezone fallback order `user -> tenant -> system` with IANA timezone validation.
+- Implemented UTC-to-local render contract endpoint using centralized formatter and refusal envelope for invalid context/timestamp paths.
+- Implemented operational feed payload contract that only returns localized display values (`occurredAtLocal`) and excludes raw UTC fields from UI-oriented rows.
+- Added automated AC coverage:
+  - AC1 covered by fallback/resolve tests in `src/src/__tests__/centralizedTimeServiceContract.test.ts` and `src/src/platform/time/__tests__/timezoneService.test.ts`.
+  - AC2 covered by operations-feed contract assertion that raw UTC fields are omitted plus refusal-path coverage.
+- Full backend Jest suite passes after changes.
+
+### Implementation Plan
+
+- Keep the change kernel-scoped and isolated in existing platform contracts route.
+- Centralize timezone validation, fallback resolution, and formatting in a single platform service.
+- Enforce refusal envelope for unresolved timezone context to preserve shared API contract semantics.
+- Validate behavior with both unit-level and route contract coverage.
 
 ### File List
 
--
+- `src/src/platform/time/timezoneService.ts`
+- `src/src/platform/time/__tests__/timezoneService.test.ts`
+- `src/src/routes/api/v1/platform-contracts.ts`
+- `src/src/__tests__/centralizedTimeServiceContract.test.ts`
+- `_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+## Change Log
+
+- 2026-02-18: Implemented centralized timezone fallback/formatting service, added platform time endpoints and operational feed UTC-redaction contract behavior, and added automated AC1/AC2 backend coverage.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -48,7 +48,7 @@ development_status:
   0-5-shared-api-envelope-and-business-refusal-contract: done
   0-6-platform-events-and-outbox-schema-foundations: done
   0-7-mutation-transaction-wrapper-with-mandatory-event-outbox-writes: review
-  0-8-centralized-time-service-and-utc-local-rendering-contract: ready-for-dev
+  0-8-centralized-time-service-and-utc-local-rendering-contract: review
   0-9-ci-policy-gate-as-blocking-first-stage: ready-for-dev
   0-10-kernel-readiness-verification-suite: ready-for-dev
   epic-0-retrospective: optional

--- a/_bmad-output/test-artifacts/atdd-checklist-0-8.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-0-8.md
@@ -1,0 +1,316 @@
+---
+stepsCompleted:
+  - 'step-01-preflight-and-context'
+  - 'step-02-generation-mode'
+  - 'step-03-test-strategy'
+  - 'step-04c-aggregate'
+  - 'step-05-validate-and-complete'
+lastStep: 'step-05-validate-and-complete'
+lastSaved: '2026-02-17T17:06:00Z'
+---
+
+# ATDD Checklist - Epic 0, Story 8: Centralized Time Service and UTC/Local Rendering Contract
+
+**Date:** 2026-02-17
+**Author:** Jeremiah
+**Primary Test Level:** API
+
+---
+
+## Story Summary
+
+This story defines a centralized time-rendering contract where persistence remains UTC while operational UI receives local-time rendering. The contract requires deterministic fallback selection (`user -> tenant -> system`) and explicitly prevents raw UTC values from being shown in operational experiences.
+
+**As a** product operator  
+**I want** a unified date-time pipeline  
+**So that** users/admin always see local timezone while storage remains UTC
+
+---
+
+## Acceptance Criteria
+
+1. UTC storage and local display are enforced with fallback (`user -> tenant -> system`)
+2. contract tests confirm raw UTC is not displayed in operational UI responses
+
+---
+
+## Failing Tests Created (RED Phase)
+
+### E2E Tests (3 tests)
+
+**File:** `tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts` (80 lines)
+
+- ✅ **Test:** `[P0] renders localized operation time from utc in operational grid`
+  - **Status:** RED (skipped intentionally) - `/operations` UI/route contract not implemented
+  - **Verifies:** localized display value is rendered for operation rows
+- ✅ **Test:** `[P1] shows tenant fallback indicator when user timezone is unavailable`
+  - **Status:** RED (skipped intentionally) - fallback indicator and render-context endpoint not implemented
+  - **Verifies:** timezone source fallback is visible when user preference is absent
+- ✅ **Test:** `[P1] never surfaces raw utc iso text in operational ui elements`
+  - **Status:** RED (skipped intentionally) - UTC suppression contract not implemented
+  - **Verifies:** raw ISO UTC text does not appear in operational UI
+
+### API Tests (3 tests)
+
+**File:** `tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts` (68 lines)
+
+- ✅ **Test:** `[P0] resolves timezone fallback in strict order user -> tenant -> system`
+  - **Status:** RED (skipped intentionally) - render-context endpoint contract not implemented
+  - **Verifies:** fallback precedence resolves correctly
+- ✅ **Test:** `[P1] returns localized timestamps for operational payload contract`
+  - **Status:** RED (skipped intentionally) - render-contract endpoint not implemented
+  - **Verifies:** UTC input can be transformed to localized payload contract
+- ✅ **Test:** `[P1] contract endpoint omits raw utc strings in operational-ui response envelope`
+  - **Status:** RED (skipped intentionally) - feed contract not yet enforcing presentation invariant
+  - **Verifies:** operational responses are UI-safe (no raw UTC strings)
+
+### Component Tests (0 tests)
+
+Component-level coverage deferred. Story scope is currently contract and integration level.
+
+---
+
+## Data Factories Created
+
+### Timezone Context Factory
+
+**File:** `tests/support/factories/timezoneContextFactory.ts`
+
+**Exports:**
+
+- `createTimezoneContext(overrides?)` - Create timezone headers/context with fallback metadata and correlation id
+
+---
+
+## Fixtures Created
+
+### Timezone Context Fixture
+
+**File:** `tests/support/fixtures/timezoneContext.fixture.ts`
+
+**Fixtures:**
+
+- `timezoneContext` - Provides generated timezone context for tests
+  - **Setup:** creates context via `createTimezoneContext()`
+  - **Provides:** user/tenant/system timezone metadata and headers
+  - **Cleanup:** none needed (pure in-memory data)
+
+---
+
+## Mock Requirements
+
+### Time Rendering Contract Mock
+
+**Endpoint:** `GET /api/v1/platform/time/render-context`
+
+**Success Response:**
+
+```json
+{
+  "timezone": "America/Chicago",
+  "timezoneSource": "tenant"
+}
+```
+
+**Failure Response:**
+
+```json
+{
+  "code": "TIMEZONE_CONTEXT_UNRESOLVED",
+  "message": "Unable to resolve timezone context"
+}
+```
+
+### Operations Feed Contract Mock
+
+**Endpoint:** `GET /api/v1/platform/operations/feed`
+
+**Success Response:**
+
+```json
+{
+  "rows": [
+    {
+      "id": "op-001",
+      "occurredAtUtc": "2026-02-17T15:30:00.000Z",
+      "occurredAtLocal": "2026-02-17 10:30 AM",
+      "timezoneSource": "user"
+    }
+  ]
+}
+```
+
+**Failure Response:**
+
+```json
+{
+  "code": "OPERATIONS_FEED_UNAVAILABLE",
+  "message": "Unable to generate operations feed"
+}
+```
+
+---
+
+## Required data-testid Attributes
+
+### Operations Screen
+
+- `operations-time-cell` - Localized date-time display cell in operations table/grid
+- `timezone-source-badge` - Badge indicating fallback source (`user|tenant|system`)
+- `operations-row` - Row container used for deterministic row assertions
+
+---
+
+## Implementation Checklist
+
+### Test: `[P0] resolves timezone fallback in strict order user -> tenant -> system`
+
+**File:** `tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts`
+
+**Tasks to make this test pass:**
+
+- [ ] Implement centralized timezone resolver in platform kernel
+- [ ] Enforce precedence chain `user -> tenant -> system`
+- [ ] Implement `GET /api/v1/platform/time/render-context`
+- [ ] Return stable response contract including `timezoneSource`
+- [ ] Run test: `npx playwright test tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts`
+- [ ] ✅ Test passes (green phase)
+
+**Estimated Effort:** 3 hours
+
+### Test: `[P1] returns localized timestamps for operational payload contract`
+
+**File:** `tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts`
+
+**Tasks to make this test pass:**
+
+- [ ] Implement UTC->local rendering service entrypoint for operations payloads
+- [ ] Implement `POST /api/v1/platform/time/render-contract`
+- [ ] Ensure timestamps remain UTC at storage boundary
+- [ ] Return localized render fields for operational consumers
+- [ ] Run test: `npx playwright test tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts`
+- [ ] ✅ Test passes (green phase)
+
+**Estimated Effort:** 4 hours
+
+### Test: `[P1] never surfaces raw utc iso text in operational ui elements`
+
+**File:** `tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts`
+
+**Tasks to make this test pass:**
+
+- [ ] Add operational UI rendering path for localized time values
+- [ ] Prevent direct binding of raw UTC fields in operational components
+- [ ] Add required data-testid attributes: `operations-time-cell`, `timezone-source-badge`, `operations-row`
+- [ ] Confirm fallback source badge handling in UI
+- [ ] Run test: `npx playwright test tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts`
+- [ ] ✅ Test passes (green phase)
+
+**Estimated Effort:** 4 hours
+
+---
+
+## Running Tests
+
+```bash
+# Run all failing tests for this story
+npx playwright test tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts
+
+# Run specific test file
+npx playwright test tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts
+
+# Run tests in headed mode (see browser)
+npx playwright test tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts --headed
+
+# Debug specific test
+npx playwright test tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts --debug
+
+# Run tests with coverage (if configured)
+npx playwright test --coverage
+```
+
+---
+
+## Red-Green-Refactor Workflow
+
+### RED Phase (Complete) ✅
+
+- ✅ Tests authored before implementation
+- ✅ API and E2E contracts mapped directly to story acceptance criteria
+- ✅ Supporting factory/fixture scaffolding added
+- ✅ Implementation checklist prepared
+
+### GREEN Phase (DEV Team - Next Steps)
+
+1. Implement centralized timezone service and fallback chain.
+2. Implement operational render-contract endpoints.
+3. Wire UI rendering to localized output only.
+4. Remove `test.skip()` markers from story tests.
+5. Execute tests and iterate until green.
+
+### REFACTOR Phase (DEV Team - After All Tests Pass)
+
+1. Consolidate timezone logic in one service boundary.
+2. Remove duplication across API and UI adapters.
+3. Harden contract typing and error envelopes.
+4. Re-run full platform test set for regression confidence.
+
+---
+
+## Next Steps
+
+1. Hand off checklist and RED tests to DEV workflow.
+2. Implement feature with one test-at-a-time progression.
+3. Remove `test.skip()` once implementation exists.
+4. Re-run the two story spec files and confirm green.
+
+---
+
+## Knowledge Base References Applied
+
+- `data-factories.md`
+- `component-tdd.md`
+- `test-quality.md`
+- `test-healing-patterns.md`
+- `selector-resilience.md`
+- `timing-debugging.md`
+- `overview.md`
+- `api-request.md`
+- `network-recorder.md`
+- `auth-session.md`
+- `intercept-network-call.md`
+- `recurse.md`
+- `log.md`
+- `file-utils.md`
+- `network-error-monitor.md`
+- `fixtures-composition.md`
+- `playwright-cli.md`
+- `api-testing-patterns.md`
+
+---
+
+## Test Execution Evidence
+
+### Initial Test Run (RED Phase Verification)
+
+**Command:**  
+`npx playwright test tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts`
+
+**Results:** Not executed in this run. RED-phase intent is represented by `test.skip()` scaffolding and implementation checklist handoff.
+
+**Expected Failure Messages (after removing skip pre-implementation):**
+
+- `GET /api/v1/platform/time/render-context` returns `404` or missing contract fields
+- `POST /api/v1/platform/time/render-contract` returns `404` or missing localized render fields
+- `/operations` UI lacks localized time rendering and fallback badge contract
+
+---
+
+## Notes
+
+- Story scope remains Phase-0 and avoids module-specific behavior outside kernel/platform contracts.
+- Tests are intentionally authored in RED mode with `test.skip()` to stage implementation handoff safely.
+
+---
+
+**Generated by BMad TEA Agent** - 2026-02-17

--- a/_bmad-output/test-artifacts/automation-summary.md
+++ b/_bmad-output/test-artifacts/automation-summary.md
@@ -6,20 +6,20 @@ stepsCompleted:
   - step-03c-aggregate
   - step-04-validate-and-summarize
 lastStep: step-04-validate-and-summarize
-lastSaved: 2026-02-17T21:50:58Z
-storyId: '0-7'
-storyFile: '/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-7-mutation-transaction-wrapper-with-mandatory-event-outbox-writes.md'
-subprocessTimestamp: '2026-02-17T21-50-58Z'
+lastSaved: 2026-02-17T22:27:59Z
+storyId: '0-8'
+storyFile: '/Users/jeremiahotis/moneyshyft/_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md'
+subprocessTimestamp: '2026-02-17T22-27-59Z'
 executionMode: 'BMad-Integrated'
 ---
 
-# Test Automation Summary - Story 0.7
+# Test Automation Summary - Story 0.8
 
 ## Step 1 - Preflight and Context
 - Mode: BMad-Integrated
 - Input artifacts loaded:
-  - `_bmad-output/implementation-artifacts/0-7-mutation-transaction-wrapper-with-mandatory-event-outbox-writes.md`
-  - `_bmad-output/test-artifacts/atdd-checklist-0-7.md`
+  - `_bmad-output/implementation-artifacts/0-8-centralized-time-service-and-utc-local-rendering-contract.md`
+  - `_bmad-output/test-artifacts/atdd-checklist-0-8.md`
 - Framework readiness:
   - `playwright.config.ts` exists
   - `@playwright/test` present in `package.json`
@@ -27,91 +27,76 @@ executionMode: 'BMad-Integrated'
 - TEA config flags:
   - `tea_use_playwright_utils=true`
   - `tea_browser_automation=auto`
-- Story implementation status discovered:
-  - `src/src/routes/api/v1/platform-contracts.ts` does not yet implement Story 0.7 contract endpoints:
-    - `POST /api/v1/platform/_kernel/contracts/mutation/transaction-wrapper/atomic`
-    - `POST /api/v1/platform/_kernel/contracts/mutation/transaction-wrapper/validate-required-writes`
 
-Knowledge fragments loaded:
-- Core: `test-levels`, `test-priorities`, `data-factories`, `selective-testing`, `ci-burn-in`, `test-quality`
-- Playwright utils + automation: `overview`, `api-request`, `network-recorder`, `auth-session`, `intercept-network-call`, `recurse`, `log`, `file-utils`, `burn-in`, `network-error-monitor`, `fixtures-composition`, `playwright-cli`
-- Additional for current target: `api-testing-patterns`, `selector-resilience`
+Knowledge fragments applied:
+- Core: `test-levels-framework`, `test-priorities-matrix`, `data-factories`, `selective-testing`, `ci-burn-in`, `test-quality`
+- API/E2E generation support: `api-request`, `api-testing-patterns`, `fixture-architecture`, `network-first`, `selector-resilience`, `playwright-cli`
 
 ## Step 2 - Coverage Plan
 Coverage target: `critical-paths`
 
 ### API targets
 - P0:
-  - atomic domain write + event write + outbox write contract confirmation
-  - refusal contract when event write is missing
-  - refusal contract when outbox write is missing
+  - fallback precedence contract (`user -> tenant -> system`)
 - P1:
-  - refusal contract when both event and outbox writes are missing
-  - refusal guarantees `transaction.committed === false` for missing-required-write paths
-  - tenant/correlation metadata continuity across atomic + refusal endpoints
+  - localized render payload contract from UTC input
+  - operational feed envelope shape with local display fields
+  - system fallback when user and tenant preferences are absent
+  - refusal envelope when timezone context cannot be resolved
 
 ### E2E targets
 - P0:
-  - atomic mutation contract journey with required writes present
-  - missing-event refusal journey
-  - missing-outbox refusal journey
+  - operations screen renders localized timestamp and source badge
 - P1:
-  - correlation metadata stability across refusal branches
+  - tenant fallback source badge visibility
+  - raw UTC suppression in operational cells
+  - system fallback badge visibility
+  - deterministic multi-row rendering of localized values
 
 ### Duplicate-coverage handling
-- Reused existing Story 0.7 ATDD files and expanded them in-place to avoid duplicate specs.
+- Expanded existing Story 0.8 ATDD files in place to avoid duplicate spec proliferation.
 
 ## Step 3 - Parallel Generation + Aggregation
-Subprocess outputs:
-- `/tmp/tea-automate-api-tests-2026-02-17T21-50-58Z.json`
-- `/tmp/tea-automate-e2e-tests-2026-02-17T21-50-58Z.json`
+Generated artifacts (in-place updates):
+- `tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts`
+  - expanded from 3 to 5 API tests
+- `tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts`
+  - expanded from 3 to 5 E2E tests
 
-Aggregate summary:
-- `/tmp/tea-automate-summary-2026-02-17T21-50-58Z.json`
-
-Files updated:
-- `tests/api/platform/mutation-transaction-wrapper-with-mandatory-event-outbox-writes.api.spec.ts`
-  - expanded from 4 to 6 API tests
-- `tests/e2e/platform/mutation-transaction-wrapper-with-mandatory-event-outbox-writes.spec.ts`
-  - expanded from 3 to 4 E2E tests
-- `tests/support/factories/mutationTransactionWrapperFactory.ts`
-  - added `missingWrite: 'both'` support for dual-missing-write refusal coverage
-- `tests/support/fixtures/mutationTransactionWrapper.fixture.ts`
-  - added `missingBothProbe` fixture
-
-Fixture infrastructure:
-- Reused existing support stack (no new scaffold files required):
-  - `tests/support/factories/mutationTransactionWrapperFactory.ts`
-  - `tests/support/fixtures/mutationTransactionWrapper.fixture.ts`
-  - `tests/support/helpers/apiClient.ts`
+Infrastructure reused:
+- `tests/support/factories/timezoneContextFactory.ts`
+- `tests/support/fixtures/timezoneContext.fixture.ts`
+- `tests/support/helpers/apiClient.ts`
 
 Aggregated totals:
 - Total tests: 10
-  - API: 6
-  - E2E: 4
+  - API: 5
+  - E2E: 5
 - Priority coverage:
-  - P0: 6
-  - P1: 4
+  - P0: 2
+  - P1: 8
   - P2: 0
   - P3: 0
 
 ## Step 4 - Validation
 Checklist outcome:
 - Framework readiness: pass
-- Coverage mapping to Story 0.7 ACs: pass
-- Test quality structure: pass (priority tags, deterministic assertions, no hard waits)
-- Fixtures/factories/helpers: pass (reused existing architecture, expanded where needed)
-- CLI sessions cleaned: pass (no CLI browser sessions opened)
-- Temp artifacts location: pass (`/tmp` and `_bmad-output/test-artifacts`)
+- Coverage mapping to Story 0.8 acceptance criteria: pass
+- Test structure and priority tagging: pass
+- Network-first ordering in E2E mocks (route before goto): pass
+- CLI sessions cleaned: pass (no browser CLI session opened)
+- Artifacts location: pass (`tests/` and `_bmad-output/test-artifacts/`)
 
 Execution validation:
-- `npm run test:e2e -- --list tests/api/platform/mutation-transaction-wrapper-with-mandatory-event-outbox-writes.api.spec.ts tests/e2e/platform/mutation-transaction-wrapper-with-mandatory-event-outbox-writes.spec.ts`
-- Result: 10 tests discovered successfully in 2 files
+- Command:
+  - `npm run test:e2e -- --list tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts`
+- Result:
+  - 10 tests discovered in 2 files.
 
 Assumptions and risks:
-- Story 0.7 backend contract endpoints are not implemented yet; Story 0.7 tests remain intentionally `test.skip(...)` for red-phase enforcement.
-- Green-phase activation requires implementing the two Story 0.7 contract endpoints and then removing `test.skip` incrementally (P0 before P1).
+- Story 0.8 platform endpoints and operations UI contract remain implementation-dependent; tests are intentionally kept in RED-phase (`test.skip`).
+- Assertions currently define the target contract and may need small schema alignment once implementation lands.
 
 ## Recommended Next Workflow
-- `RV` (Review Tests): quality scorecard and anti-pattern scan.
-- `TR` (Trace Requirements): map Story 0.7 ACs to these 10 tests and gate readiness.
+- `RV` (Review Tests): run quality review against these 10 tests.
+- `TR` (Trace Requirements): map Story 0.8 ACs to generated tests and gate readiness.

--- a/src/src/__tests__/centralizedTimeServiceContract.test.ts
+++ b/src/src/__tests__/centralizedTimeServiceContract.test.ts
@@ -68,6 +68,55 @@ describe('Story 0.8 - centralized time service and utc/local rendering contract'
   });
 
   describe('AC2: no raw UTC in operational UI response contract', () => {
+    it('returns localized render contract payload without raw UTC timestamp field', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .post('/api/v1/platform/time/render-contract')
+        .set('x-correlation-id', 'corr-time-render-alpha')
+        .set('x-user-timezone', 'America/New_York')
+        .set('x-tenant-timezone', 'America/Chicago')
+        .set('x-system-timezone', 'UTC')
+        .send({
+          utcTimestamp: '2026-02-17T15:30:00.000Z',
+          purpose: 'operations-ui'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'TIMEZONE_RENDER_CONTRACT_READY',
+        data: {
+          rendered: expect.any(String),
+          timezone: 'America/New_York',
+          timezoneSource: 'user',
+          purpose: 'operations-ui'
+        }
+      });
+      expect(response.body?.data).not.toHaveProperty('utcTimestamp');
+    });
+
+    it('returns business refusal for non-UTC timestamp inputs', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .post('/api/v1/platform/time/render-contract')
+        .set('x-correlation-id', 'corr-time-render-invalid-alpha')
+        .set('x-user-timezone', 'America/New_York')
+        .set('x-tenant-timezone', 'America/Chicago')
+        .set('x-system-timezone', 'UTC')
+        .send({
+          utcTimestamp: '2026-02-17T15:30:00-05:00'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'INVALID_UTC_TIMESTAMP',
+        refusalType: 'business'
+      });
+    });
+
     it('returns localized values and omits UTC ISO in operations feed payload', async () => {
       const app = buildApp();
 

--- a/src/src/__tests__/centralizedTimeServiceContract.test.ts
+++ b/src/src/__tests__/centralizedTimeServiceContract.test.ts
@@ -1,0 +1,120 @@
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import request from 'supertest';
+import { registerPlatformMiddleware } from '../api/registerRoutes';
+import contractsRouter from '../routes/api/v1/platform-contracts';
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+describe('Story 0.8 - centralized time service and utc/local rendering contract', () => {
+  const buildApp = () => {
+    const testApp = express();
+    testApp.use(cookieParser());
+    testApp.use(express.json());
+    registerPlatformMiddleware(testApp);
+    testApp.use('/api/v1/platform', contractsRouter);
+    return testApp;
+  };
+
+  describe('AC1: fallback order user -> tenant -> system', () => {
+    it('resolves tenant timezone when user timezone is unavailable', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .get('/api/v1/platform/time/render-context')
+        .set('x-correlation-id', 'corr-time-tenant-alpha')
+        .set('x-user-timezone', '')
+        .set('x-tenant-timezone', 'America/Chicago')
+        .set('x-system-timezone', 'UTC');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'TIMEZONE_CONTEXT_RESOLVED',
+        data: {
+          timezone: 'America/Chicago',
+          timezoneSource: 'tenant'
+        }
+      });
+    });
+
+    it('falls back to system timezone when user and tenant are unavailable', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .get('/api/v1/platform/time/render-context')
+        .set('x-correlation-id', 'corr-time-system-alpha')
+        .set('x-user-timezone', '')
+        .set('x-tenant-timezone', '')
+        .set('x-system-timezone', 'UTC');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'TIMEZONE_CONTEXT_RESOLVED',
+        data: {
+          timezone: 'UTC',
+          timezoneSource: 'system'
+        }
+      });
+    });
+  });
+
+  describe('AC2: no raw UTC in operational UI response contract', () => {
+    it('returns localized values and omits UTC ISO in operations feed payload', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .get('/api/v1/platform/operations/feed')
+        .set('x-correlation-id', 'corr-time-feed-alpha')
+        .set('x-user-timezone', 'America/New_York')
+        .set('x-tenant-timezone', 'America/Chicago')
+        .set('x-system-timezone', 'UTC');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'OPERATIONS_FEED_READY',
+        data: {
+          rows: expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.any(String),
+              occurredAtLocal: expect.any(String),
+              timezoneSource: 'user'
+            })
+          ])
+        }
+      });
+
+      const rows = response.body?.data?.rows ?? [];
+      rows.forEach((row: Record<string, unknown>) => {
+        expect(row).not.toHaveProperty('occurredAtUtc');
+      });
+    });
+
+    it('returns business refusal when timezone context cannot be resolved', async () => {
+      const app = buildApp();
+
+      const response = await request(app)
+        .get('/api/v1/platform/time/render-context')
+        .set('x-correlation-id', 'corr-time-refusal-alpha')
+        .set('x-user-timezone', '')
+        .set('x-tenant-timezone', '')
+        .set('x-system-timezone', '');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'TIMEZONE_CONTEXT_UNRESOLVED',
+        refusalType: 'business'
+      });
+    });
+  });
+});

--- a/src/src/platform/time/__tests__/timezoneService.test.ts
+++ b/src/src/platform/time/__tests__/timezoneService.test.ts
@@ -1,6 +1,7 @@
 import {
   formatUtcTimestampForTimezone,
   isValidIanaTimezone,
+  isStrictUtcIsoTimestamp,
   resolveTimezoneContext
 } from '../timezoneService';
 
@@ -61,6 +62,19 @@ describe('timezoneService', () => {
     });
   });
 
+  describe('isStrictUtcIsoTimestamp', () => {
+    it('accepts strict UTC ISO-8601 timestamps', () => {
+      expect(isStrictUtcIsoTimestamp('2026-02-17T15:30:00.000Z')).toBe(true);
+      expect(isStrictUtcIsoTimestamp('2026-02-17T15:30:00Z')).toBe(true);
+    });
+
+    it('rejects non-UTC or malformed timestamps', () => {
+      expect(isStrictUtcIsoTimestamp('2026-02-17T15:30:00-05:00')).toBe(false);
+      expect(isStrictUtcIsoTimestamp('2026-02-17T15:30:00')).toBe(false);
+      expect(isStrictUtcIsoTimestamp('2026-02-31T15:30:00Z')).toBe(false);
+    });
+  });
+
   describe('formatUtcTimestampForTimezone', () => {
     it('formats UTC timestamp into local display string', () => {
       const rendered = formatUtcTimestampForTimezone('2026-02-17T15:30:00.000Z', 'America/New_York');
@@ -71,6 +85,11 @@ describe('timezoneService', () => {
 
     it('returns null for invalid UTC inputs', () => {
       const rendered = formatUtcTimestampForTimezone('invalid-ts', 'America/New_York');
+      expect(rendered).toBeNull();
+    });
+
+    it('returns null for non-UTC timestamp offsets', () => {
+      const rendered = formatUtcTimestampForTimezone('2026-02-17T15:30:00-05:00', 'America/New_York');
       expect(rendered).toBeNull();
     });
   });

--- a/src/src/platform/time/__tests__/timezoneService.test.ts
+++ b/src/src/platform/time/__tests__/timezoneService.test.ts
@@ -1,0 +1,77 @@
+import {
+  formatUtcTimestampForTimezone,
+  isValidIanaTimezone,
+  resolveTimezoneContext
+} from '../timezoneService';
+
+describe('timezoneService', () => {
+  describe('resolveTimezoneContext', () => {
+    it('uses user timezone when valid', () => {
+      const result = resolveTimezoneContext({
+        userTimezone: 'America/New_York',
+        tenantTimezone: 'America/Chicago',
+        systemTimezone: 'UTC'
+      });
+
+      expect(result).toEqual({
+        timezone: 'America/New_York',
+        timezoneSource: 'user'
+      });
+    });
+
+    it('falls back to tenant then system when needed', () => {
+      const tenantFallback = resolveTimezoneContext({
+        userTimezone: 'Invalid/TZ',
+        tenantTimezone: 'America/Chicago',
+        systemTimezone: 'UTC'
+      });
+
+      const systemFallback = resolveTimezoneContext({
+        userTimezone: '',
+        tenantTimezone: '',
+        systemTimezone: 'UTC'
+      });
+
+      expect(tenantFallback).toEqual({
+        timezone: 'America/Chicago',
+        timezoneSource: 'tenant'
+      });
+      expect(systemFallback).toEqual({
+        timezone: 'UTC',
+        timezoneSource: 'system'
+      });
+    });
+
+    it('returns null when no valid timezone exists', () => {
+      const result = resolveTimezoneContext({
+        userTimezone: '',
+        tenantTimezone: 'also-invalid',
+        systemTimezone: ''
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('isValidIanaTimezone', () => {
+    it('validates IANA zone identifiers', () => {
+      expect(isValidIanaTimezone('America/Chicago')).toBe(true);
+      expect(isValidIanaTimezone('UTC')).toBe(true);
+      expect(isValidIanaTimezone('Bad/Timezone')).toBe(false);
+    });
+  });
+
+  describe('formatUtcTimestampForTimezone', () => {
+    it('formats UTC timestamp into local display string', () => {
+      const rendered = formatUtcTimestampForTimezone('2026-02-17T15:30:00.000Z', 'America/New_York');
+
+      expect(rendered).toEqual(expect.any(String));
+      expect(rendered).not.toContain('2026-02-17T15:30:00.000Z');
+    });
+
+    it('returns null for invalid UTC inputs', () => {
+      const rendered = formatUtcTimestampForTimezone('invalid-ts', 'America/New_York');
+      expect(rendered).toBeNull();
+    });
+  });
+});

--- a/src/src/platform/time/timezoneService.ts
+++ b/src/src/platform/time/timezoneService.ts
@@ -1,0 +1,69 @@
+export type TimezoneSource = 'user' | 'tenant' | 'system';
+
+export type TimezoneContext = {
+  timezone: string;
+  timezoneSource: TimezoneSource;
+};
+
+type ResolveTimezoneInput = {
+  userTimezone?: unknown;
+  tenantTimezone?: unknown;
+  systemTimezone?: unknown;
+};
+
+const normalizeTimezone = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+};
+
+export const isValidIanaTimezone = (timezone: string): boolean => {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(new Date());
+    return true;
+  } catch (_error) {
+    return false;
+  }
+};
+
+export const resolveTimezoneContext = (input: ResolveTimezoneInput): TimezoneContext | null => {
+  const candidates: Array<{ timezone: string | null; timezoneSource: TimezoneSource }> = [
+    { timezone: normalizeTimezone(input.userTimezone), timezoneSource: 'user' },
+    { timezone: normalizeTimezone(input.tenantTimezone), timezoneSource: 'tenant' },
+    { timezone: normalizeTimezone(input.systemTimezone), timezoneSource: 'system' }
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate.timezone && isValidIanaTimezone(candidate.timezone)) {
+      return {
+        timezone: candidate.timezone,
+        timezoneSource: candidate.timezoneSource
+      };
+    }
+  }
+
+  return null;
+};
+
+export const formatUtcTimestampForTimezone = (
+  utcTimestamp: string,
+  timezone: string
+): string | null => {
+  const parsed = new Date(utcTimestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true
+  }).format(parsed);
+};

--- a/src/src/platform/time/timezoneService.ts
+++ b/src/src/platform/time/timezoneService.ts
@@ -11,6 +11,8 @@ type ResolveTimezoneInput = {
   systemTimezone?: unknown;
 };
 
+const UTC_ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
 const normalizeTimezone = (value: unknown): string | null => {
   if (typeof value !== 'string') {
     return null;
@@ -48,22 +50,40 @@ export const resolveTimezoneContext = (input: ResolveTimezoneInput): TimezoneCon
   return null;
 };
 
+export const isStrictUtcIsoTimestamp = (timestamp: string): boolean => {
+  if (!UTC_ISO_8601_PATTERN.test(timestamp)) {
+    return false;
+  }
+
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return false;
+  }
+
+  const normalizedInput = timestamp.includes('.') ? timestamp : timestamp.replace('Z', '.000Z');
+  return parsed.toISOString() === normalizedInput;
+};
+
 export const formatUtcTimestampForTimezone = (
   utcTimestamp: string,
   timezone: string
 ): string | null => {
-  const parsed = new Date(utcTimestamp);
-  if (Number.isNaN(parsed.getTime())) {
+  if (!isStrictUtcIsoTimestamp(utcTimestamp) || !isValidIanaTimezone(timezone)) {
     return null;
   }
 
-  return new Intl.DateTimeFormat('en-US', {
-    timeZone: timezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: true
-  }).format(parsed);
+  const parsed = new Date(utcTimestamp);
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true
+    }).format(parsed);
+  } catch (_error) {
+    return null;
+  }
 };

--- a/src/src/routes/api/v1/platform-contracts.ts
+++ b/src/src/routes/api/v1/platform-contracts.ts
@@ -107,7 +107,6 @@ router.post('/time/render-contract', (req: Request, res: Response) => {
     code: 'TIMEZONE_RENDER_CONTRACT_READY',
     message: 'UTC timestamp converted to localized display value',
     data: {
-      utcTimestamp,
       rendered,
       timezone: context.timezone,
       timezoneSource: context.timezoneSource,
@@ -135,11 +134,24 @@ router.get('/operations/feed', (req: Request, res: Response) => {
     { id: 'op-002', occurredAtUtc: '2026-02-17T18:45:00.000Z' }
   ];
 
-  const rows = sourceRows.map((row) => ({
-    id: row.id,
-    occurredAtLocal: formatUtcTimestampForTimezone(row.occurredAtUtc, context.timezone),
-    timezoneSource: context.timezoneSource
-  }));
+  const rows: Array<{ id: string; occurredAtLocal: string; timezoneSource: typeof context.timezoneSource }> = [];
+
+  for (const row of sourceRows) {
+    const occurredAtLocal = formatUtcTimestampForTimezone(row.occurredAtUtc, context.timezone);
+
+    if (!occurredAtLocal) {
+      return refusal(res, {
+        code: 'INVALID_UTC_TIMESTAMP',
+        message: `Operational row ${row.id} contains an invalid UTC timestamp`
+      });
+    }
+
+    rows.push({
+      id: row.id,
+      occurredAtLocal,
+      timezoneSource: context.timezoneSource
+    });
+  }
 
   return success(res, {
     code: 'OPERATIONS_FEED_READY',

--- a/src/src/routes/api/v1/platform-contracts.ts
+++ b/src/src/routes/api/v1/platform-contracts.ts
@@ -1,5 +1,9 @@
 import { Request, Response, Router } from 'express';
 import { refusal, success, systemError } from '../../../platform/envelopes/response';
+import {
+  formatUtcTimestampForTimezone,
+  resolveTimezoneContext
+} from '../../../platform/time/timezoneService';
 
 const router = Router();
 
@@ -51,6 +55,100 @@ router.post('/_kernel/contracts/envelope/system-error', (req: Request, res: Resp
     message,
     data: req.body?.data,
     httpStatus
+  });
+});
+
+router.get('/time/render-context', (req: Request, res: Response) => {
+  const context = resolveTimezoneContext({
+    userTimezone: req.header('x-user-timezone'),
+    tenantTimezone: req.header('x-tenant-timezone'),
+    systemTimezone: req.header('x-system-timezone')
+  });
+
+  if (!context) {
+    return refusal(res, {
+      code: 'TIMEZONE_CONTEXT_UNRESOLVED',
+      message: 'Unable to resolve timezone context using fallback order user -> tenant -> system'
+    });
+  }
+
+  return success(res, {
+    code: 'TIMEZONE_CONTEXT_RESOLVED',
+    message: 'Timezone context resolved for localized rendering',
+    data: context
+  });
+});
+
+router.post('/time/render-contract', (req: Request, res: Response) => {
+  const context = resolveTimezoneContext({
+    userTimezone: req.header('x-user-timezone'),
+    tenantTimezone: req.header('x-tenant-timezone'),
+    systemTimezone: req.header('x-system-timezone')
+  });
+
+  if (!context) {
+    return refusal(res, {
+      code: 'TIMEZONE_CONTEXT_UNRESOLVED',
+      message: 'Unable to resolve timezone context using fallback order user -> tenant -> system'
+    });
+  }
+
+  const utcTimestamp = typeof req.body?.utcTimestamp === 'string' ? req.body.utcTimestamp : '';
+  const rendered = formatUtcTimestampForTimezone(utcTimestamp, context.timezone);
+
+  if (!rendered) {
+    return refusal(res, {
+      code: 'INVALID_UTC_TIMESTAMP',
+      message: 'utcTimestamp must be a valid UTC ISO-8601 timestamp'
+    });
+  }
+
+  return success(res, {
+    code: 'TIMEZONE_RENDER_CONTRACT_READY',
+    message: 'UTC timestamp converted to localized display value',
+    data: {
+      utcTimestamp,
+      rendered,
+      timezone: context.timezone,
+      timezoneSource: context.timezoneSource,
+      purpose: typeof req.body?.purpose === 'string' ? req.body.purpose : 'unspecified'
+    }
+  });
+});
+
+router.get('/operations/feed', (req: Request, res: Response) => {
+  const context = resolveTimezoneContext({
+    userTimezone: req.header('x-user-timezone'),
+    tenantTimezone: req.header('x-tenant-timezone'),
+    systemTimezone: req.header('x-system-timezone')
+  });
+
+  if (!context) {
+    return refusal(res, {
+      code: 'TIMEZONE_CONTEXT_UNRESOLVED',
+      message: 'Unable to resolve timezone context using fallback order user -> tenant -> system'
+    });
+  }
+
+  const sourceRows = [
+    { id: 'op-001', occurredAtUtc: '2026-02-17T15:30:00.000Z' },
+    { id: 'op-002', occurredAtUtc: '2026-02-17T18:45:00.000Z' }
+  ];
+
+  const rows = sourceRows.map((row) => ({
+    id: row.id,
+    occurredAtLocal: formatUtcTimestampForTimezone(row.occurredAtUtc, context.timezone),
+    timezoneSource: context.timezoneSource
+  }));
+
+  return success(res, {
+    code: 'OPERATIONS_FEED_READY',
+    message: 'Operational feed prepared with localized timestamps',
+    data: {
+      timezone: context.timezone,
+      timezoneSource: context.timezoneSource,
+      rows
+    }
   });
 });
 

--- a/tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts
+++ b/tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { apiRequest } from '../../support/helpers/apiClient';
+import { createTimezoneContext } from '../../support/factories/timezoneContextFactory';
+
+test.describe('Story 0.8 atdd - centralized time service and utc/local rendering contract API coverage', () => {
+  test.skip('[P0] resolves timezone fallback in strict order user -> tenant -> system @P0', async ({ request }) => {
+    // Given a request where user timezone is absent and tenant timezone is available
+    const timezoneContext = createTimezoneContext({
+      userTimezone: null,
+      tenantTimezone: 'America/Chicago',
+      systemTimezone: 'UTC',
+    });
+
+    // When asking for operational render context
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/time/render-context',
+      headers: timezoneContext.headers,
+    });
+
+    // Then tenant fallback should be selected
+    expect(response.status()).toBe(200);
+  });
+
+  test.skip('[P1] returns localized timestamps for operational payload contract @P1', async ({ request }) => {
+    // Given an operational UTC timestamp and explicit user timezone
+    const timezoneContext = createTimezoneContext({
+      userTimezone: 'America/Los_Angeles',
+      tenantTimezone: 'America/Chicago',
+      systemTimezone: 'UTC',
+    });
+
+    // When requesting a render contract payload
+    const response = await apiRequest(request, {
+      method: 'POST',
+      path: '/api/v1/platform/time/render-contract',
+      headers: timezoneContext.headers,
+      data: {
+        utcTimestamp: '2026-02-17T15:30:00.000Z',
+        purpose: 'operations-listing',
+      },
+    });
+
+    // Then service should acknowledge contract generation
+    expect(response.status()).toBe(200);
+  });
+
+  test.skip('[P1] contract endpoint omits raw utc strings in operational-ui response envelope @P1', async ({ request }) => {
+    // Given an operational response feed request with timezone metadata
+    const timezoneContext = createTimezoneContext({
+      userTimezone: 'America/New_York',
+      tenantTimezone: 'America/Chicago',
+      systemTimezone: 'UTC',
+    });
+
+    // When requesting operation rows prepared for UI rendering
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/operations/feed',
+      headers: timezoneContext.headers,
+    });
+
+    // Then contract endpoint should be reachable for UI-safe values
+    expect(response.status()).toBe(200);
+  });
+});

--- a/tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts
+++ b/tests/api/platform/centralized-time-service-and-utc-local-rendering-contract.api.spec.ts
@@ -3,7 +3,9 @@ import { apiRequest } from '../../support/helpers/apiClient';
 import { createTimezoneContext } from '../../support/factories/timezoneContextFactory';
 
 test.describe('Story 0.8 atdd - centralized time service and utc/local rendering contract API coverage', () => {
-  test.skip('[P0] resolves timezone fallback in strict order user -> tenant -> system @P0', async ({ request }) => {
+  test.skip('[P0] resolves timezone fallback in strict order user -> tenant -> system @P0', async ({
+    request,
+  }) => {
     // Given a request where user timezone is absent and tenant timezone is available
     const timezoneContext = createTimezoneContext({
       userTimezone: null,
@@ -20,6 +22,12 @@ test.describe('Story 0.8 atdd - centralized time service and utc/local rendering
 
     // Then tenant fallback should be selected
     expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      timezone: 'America/Chicago',
+      timezoneSource: 'tenant',
+    });
+    expect(body.timezone).not.toBe('UTC');
   });
 
   test.skip('[P1] returns localized timestamps for operational payload contract @P1', async ({ request }) => {
@@ -43,6 +51,13 @@ test.describe('Story 0.8 atdd - centralized time service and utc/local rendering
 
     // Then service should acknowledge contract generation
     expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      timezoneSource: 'user',
+      rendered: expect.any(String),
+      utcTimestamp: '2026-02-17T15:30:00.000Z',
+    });
+    expect(body.rendered).not.toContain('T15:30:00.000Z');
   });
 
   test.skip('[P1] contract endpoint omits raw utc strings in operational-ui response envelope @P1', async ({ request }) => {
@@ -62,5 +77,67 @@ test.describe('Story 0.8 atdd - centralized time service and utc/local rendering
 
     // Then contract endpoint should be reachable for UI-safe values
     expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.rows ?? []).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          occurredAtLocal: expect.any(String),
+          timezoneSource: expect.stringMatching(/^(user|tenant|system)$/),
+        }),
+      ]),
+    );
+  });
+
+  test.skip('[P1] falls back to system timezone when user and tenant preferences are absent @P1', async ({
+    request,
+  }) => {
+    // Given a request where user and tenant timezone are both unavailable
+    const timezoneContext = createTimezoneContext({
+      userTimezone: null,
+      tenantTimezone: '',
+      systemTimezone: 'UTC',
+    });
+
+    // When asking for operational render context
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/time/render-context',
+      headers: timezoneContext.headers,
+    });
+
+    // Then system fallback should be selected and contract should declare source
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      timezone: 'UTC',
+      timezoneSource: 'system',
+    });
+  });
+
+  test.skip('[P1] returns refusal envelope when timezone context cannot be resolved @P1', async ({
+    request,
+  }) => {
+    // Given an invalid timezone context payload
+    const timezoneContext = createTimezoneContext({
+      userTimezone: '',
+      tenantTimezone: '',
+      systemTimezone: '',
+    });
+
+    // When asking for render context without a valid fallback option
+    const response = await apiRequest(request, {
+      method: 'GET',
+      path: '/api/v1/platform/time/render-context',
+      headers: timezoneContext.headers,
+    });
+
+    // Then refusal envelope should identify timezone resolution failure
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      ok: false,
+      code: 'TIMEZONE_CONTEXT_UNRESOLVED',
+      message: expect.any(String),
+    });
   });
 });

--- a/tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts
+++ b/tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../../support/fixtures/timezoneContext.fixture';
+
+test.describe('Story 0.8 atdd - centralized time service and utc/local rendering contract', () => {
+  test.skip('[P0] renders localized operation time from utc in operational grid @P0', async ({ page }) => {
+    // Given the operations page receives UTC data and timezone contract values
+    await page.route('**/api/v1/platform/operations/feed', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rows: [
+            {
+              id: 'op-001',
+              occurredAtUtc: '2026-02-17T15:30:00.000Z',
+              occurredAtLocal: '2026-02-17 10:30 AM',
+              timezoneSource: 'user',
+            },
+          ],
+        }),
+      });
+    });
+
+    // When the user opens the operations view
+    await page.goto('/operations');
+
+    // Then localized operational timestamp should be visible
+    await expect(page.getByText('2026-02-17 10:30 AM')).toBeVisible();
+  });
+
+  test.skip('[P1] shows tenant fallback indicator when user timezone is unavailable @P1', async ({ page }) => {
+    // Given user timezone is absent and tenant timezone fallback is returned
+    await page.route('**/api/v1/platform/time/render-context', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          timezone: 'America/Chicago',
+          timezoneSource: 'tenant',
+        }),
+      });
+    });
+
+    // When loading the operations screen
+    await page.goto('/operations');
+
+    // Then tenant fallback indicator should be shown
+    await expect(page.getByText('Timezone source: tenant')).toBeVisible();
+  });
+
+  test.skip('[P1] never surfaces raw utc iso text in operational ui elements @P1', async ({ page }) => {
+    // Given backend sends both utc and localized values
+    await page.route('**/api/v1/platform/operations/feed', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rows: [
+            {
+              id: 'op-002',
+              occurredAtUtc: '2026-02-17T18:45:00.000Z',
+              occurredAtLocal: '2026-02-17 01:45 PM',
+              timezoneSource: 'user',
+            },
+          ],
+        }),
+      });
+    });
+
+    // When user reviews operational rows
+    await page.goto('/operations');
+
+    // Then raw UTC ISO should not appear in the rendered UI
+    await expect(page.getByText('2026-02-17T18:45:00.000Z')).toHaveCount(0);
+  });
+});

--- a/tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts
+++ b/tests/e2e/platform/centralized-time-service-and-utc-local-rendering-contract.spec.ts
@@ -24,7 +24,8 @@ test.describe('Story 0.8 atdd - centralized time service and utc/local rendering
     await page.goto('/operations');
 
     // Then localized operational timestamp should be visible
-    await expect(page.getByText('2026-02-17 10:30 AM')).toBeVisible();
+    await expect(page.getByTestId('operations-time-cell')).toHaveText('2026-02-17 10:30 AM');
+    await expect(page.getByTestId('timezone-source-badge')).toHaveText('user');
   });
 
   test.skip('[P1] shows tenant fallback indicator when user timezone is unavailable @P1', async ({ page }) => {
@@ -44,7 +45,7 @@ test.describe('Story 0.8 atdd - centralized time service and utc/local rendering
     await page.goto('/operations');
 
     // Then tenant fallback indicator should be shown
-    await expect(page.getByText('Timezone source: tenant')).toBeVisible();
+    await expect(page.getByTestId('timezone-source-badge')).toHaveText('tenant');
   });
 
   test.skip('[P1] never surfaces raw utc iso text in operational ui elements @P1', async ({ page }) => {
@@ -71,5 +72,64 @@ test.describe('Story 0.8 atdd - centralized time service and utc/local rendering
 
     // Then raw UTC ISO should not appear in the rendered UI
     await expect(page.getByText('2026-02-17T18:45:00.000Z')).toHaveCount(0);
+    await expect(page.getByTestId('operations-time-cell')).toHaveText('2026-02-17 01:45 PM');
+  });
+
+  test.skip('[P1] shows system timezone source when user and tenant preferences are unavailable @P1', async ({
+    page,
+  }) => {
+    // Given render-context endpoint reports system fallback
+    await page.route('**/api/v1/platform/time/render-context', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          timezone: 'UTC',
+          timezoneSource: 'system',
+        }),
+      });
+    });
+
+    // When operations page is loaded
+    await page.goto('/operations');
+
+    // Then system timezone source should be explicitly displayed
+    await expect(page.getByTestId('timezone-source-badge')).toHaveText('system');
+  });
+
+  test.skip('[P1] keeps operational rows stable while rendering timezone-specific local values @P1', async ({
+    page,
+  }) => {
+    // Given backend returns multiple rows with timezone-aware local render fields
+    await page.route('**/api/v1/platform/operations/feed', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rows: [
+            {
+              id: 'op-010',
+              occurredAtUtc: '2026-02-17T15:30:00.000Z',
+              occurredAtLocal: '2026-02-17 10:30 AM',
+              timezoneSource: 'user',
+            },
+            {
+              id: 'op-011',
+              occurredAtUtc: '2026-02-17T21:15:00.000Z',
+              occurredAtLocal: '2026-02-17 04:15 PM',
+              timezoneSource: 'user',
+            },
+          ],
+        }),
+      });
+    });
+
+    // When operations page is loaded
+    await page.goto('/operations');
+
+    // Then operation row count and localized values should render deterministically
+    await expect(page.getByTestId('operations-row')).toHaveCount(2);
+    await expect(page.getByTestId('operations-time-cell').first()).toHaveText('2026-02-17 10:30 AM');
+    await expect(page.getByTestId('operations-time-cell').last()).toHaveText('2026-02-17 04:15 PM');
   });
 });

--- a/tests/support/factories/timezoneContextFactory.ts
+++ b/tests/support/factories/timezoneContextFactory.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'node:crypto';
+
+type TimezoneContextOverrides = {
+  userTimezone?: string | null;
+  tenantTimezone?: string;
+  systemTimezone?: string;
+  correlationId?: string;
+};
+
+export function createTimezoneContext(overrides: TimezoneContextOverrides = {}) {
+  const userTimezone = overrides.userTimezone ?? 'America/New_York';
+  const tenantTimezone = overrides.tenantTimezone ?? 'America/Chicago';
+  const systemTimezone = overrides.systemTimezone ?? 'UTC';
+  const correlationId = overrides.correlationId ?? randomUUID();
+
+  return {
+    userTimezone,
+    tenantTimezone,
+    systemTimezone,
+    correlationId,
+    headers: {
+      'x-user-timezone': userTimezone ?? '',
+      'x-tenant-timezone': tenantTimezone,
+      'x-system-timezone': systemTimezone,
+      'x-correlation-id': correlationId,
+    },
+  };
+}

--- a/tests/support/fixtures/timezoneContext.fixture.ts
+++ b/tests/support/fixtures/timezoneContext.fixture.ts
@@ -1,0 +1,14 @@
+import { test as base } from '@playwright/test';
+import { createTimezoneContext } from '../factories/timezoneContextFactory';
+
+type TimezoneFixtures = {
+  timezoneContext: ReturnType<typeof createTimezoneContext>;
+};
+
+export const test = base.extend<TimezoneFixtures>({
+  timezoneContext: async ({}, use) => {
+    await use(createTimezoneContext());
+  },
+});
+
+export { expect } from '@playwright/test';


### PR DESCRIPTION
## Summary
- Enforce strict UTC ISO-8601 validation in the centralized timezone service before rendering
- Remove raw utcTimestamp from /api/v1/platform/time/render-contract success payload
- Harden operations feed mapping to refuse invalid UTC source rows instead of returning nullable local timestamps
- Add contract/unit tests for invalid timestamp refusal and UTC redaction paths
- Reconcile story review record and file list with actual git changes for Story 0.8

## Validation
- cd src && npm test
- cd src && npm run build
