### PR TITLE
1-5: enforce project_lane token in story branch slugs

### DIFF
--- a/docs/policies/git_policy.md
+++ b/docs/policies/git_policy.md
@@ -23,7 +23,8 @@ Source material was imported from `~/Downloads/git_policy.md` and adapted for th
 - Required guard command before execution:
   - `npm run branch:ensure-workflow -- --workflow <name-or-path> --story <story-key-or-story-file>`
 - Required story branch naming:
-  - `codex/story-<story-id>-<short-slug>`
+  - `codex/story-<story-id>-<project-lane>-<short-slug>`
+  - `<project-lane>` token must appear in slug and match resolved lane context.
 - Story branches must be created from `codex/dev` and merged back into `codex/dev`.
 - Do not run story-scoped workflows on `master` or mismatched story branches.
 - Keep all code, tests, and story artifacts for that story on the same story branch.
@@ -137,6 +138,7 @@ Source material was imported from `~/Downloads/git_policy.md` and adapted for th
 ## 6) Project Lane Policy (Mandatory)
 
 - `project_lane` is required for planning and status artifacts.
+- Story branch lane context is resolved from `--lane`/`PROJECT_LANE`, then branch token, then `SPRINT_STATUS_FILE`, then default lane.
 - Canonical lane configuration source:
   - `docs/policies/project_lanes.json`
 - Current lane mapping:
@@ -149,6 +151,7 @@ Source material was imported from `~/Downloads/git_policy.md` and adapted for th
 - Shared implementation story files under `_bmad-output/implementation-artifacts/[epic-story].md` are cross-lane foundation artifacts and are allowed in both product repos.
 - Future modules must register a new lane in `docs/policies/project_lanes.json` before planning artifacts are created.
 - Lane enforcement is mandatory through:
+  - `scripts/project-lane-context.js`
   - `scripts/enforce-project-lane.js`
   - `scripts/enforce-git-policy.sh` (via `npm run policy:check`)
 

--- a/scripts/branch-ensure-workflow.sh
+++ b/scripts/branch-ensure-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 workflow=""
 story_input=""
 epic_input=""
+lane_override=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -29,6 +30,14 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       epic_input="$2"
+      shift 2
+      ;;
+    --lane)
+      if [[ $# -lt 2 || -z "${2-}" || "${2-}" == --* ]]; then
+        echo "Missing value for --lane"
+        exit 1
+      fi
+      lane_override="$2"
       shift 2
       ;;
     *)
@@ -109,11 +118,20 @@ resolve_branch() {
 
 branch="$(resolve_branch)"
 
+lane_context_args=(--format shell --branch "$branch")
+if [[ -n "$lane_override" ]]; then
+  lane_context_args+=(--lane "$lane_override")
+fi
+if ! lane_context="$(node scripts/project-lane-context.js "${lane_context_args[@]}")"; then
+  exit 1
+fi
+eval "$lane_context"
+
 story_workflow_regex='^(atdd|automate|create-story|dev-story|code-review|at|ta|ds|cr)$'
 epic_workflow_regex='^(sprint-planning|retrospective|correct-course)$'
 phase0_status_file="${PHASE0_READINESS_STATUS_FILE:-_bmad-output/implementation-artifacts/phase0-readiness.json}"
 readiness_api_spec="${PHASE0_READINESS_API_SPEC:-tests/api/platform/kernel-readiness-verification-suite.api.spec.ts}"
-sprint_status_file="${SPRINT_STATUS_FILE:-_bmad-output/implementation-artifacts/sprint-status.yaml}"
+sprint_status_file="${SPRINT_STATUS_FILE:-$LANE_SPRINT_STATUS_FILE}"
 
 normalize_story_id() {
   local raw="$1"
@@ -310,11 +328,22 @@ if [[ "$workflow_key" =~ $story_workflow_regex ]]; then
 
   ensure_corrected_kernel_gate "$story_id"
 
-  if [[ ! "$branch" =~ ^codex/story-${story_id}- ]]; then
+  if [[ ! "$branch" =~ ^codex/story-${story_id}-(.+)$ ]]; then
     echo "Branch guard failed"
     echo "Workflow key: $workflow_key"
-    echo "Expected branch pattern: codex/story-${story_id}-<slug>"
+    echo "Expected branch pattern: codex/story-${story_id}-${LANE_SLUG_TOKEN}-<slug>"
     echo "Current branch: $branch"
+    echo "Resolved project lane: $ACTIVE_LANE"
+    exit 1
+  fi
+  story_slug="${BASH_REMATCH[1]}"
+
+  if [[ "-$story_slug-" != *-"$LANE_SLUG_TOKEN"-* ]]; then
+    echo "Branch guard failed"
+    echo "Workflow key: $workflow_key"
+    echo "Expected branch pattern: codex/story-${story_id}-${LANE_SLUG_TOKEN}-<slug>"
+    echo "Current branch: $branch"
+    echo "Resolved project lane: $ACTIVE_LANE"
     exit 1
   fi
 

--- a/scripts/enforce-git-policy.sh
+++ b/scripts/enforce-git-policy.sh
@@ -67,6 +67,16 @@ fi
 
 event="${GITHUB_EVENT_NAME:-local}"
 branch="$(resolve_branch)"
+lane_context_args=(--format shell --branch "$branch")
+if [[ -n "${PROJECT_LANE:-}" ]]; then
+  lane_context_args+=(--lane "$PROJECT_LANE")
+fi
+if ! lane_context="$(node scripts/project-lane-context.js "${lane_context_args[@]}")"; then
+  echo "Policy check failed: unable to resolve project lane context"
+  exit 1
+fi
+eval "$lane_context"
+lane_sprint_status_file="${SPRINT_STATUS_FILE:-$LANE_SPRINT_STATUS_FILE}"
 base_branch="${GITHUB_BASE_REF:-}"
 is_default_branch=false
 if [[ "$branch" == "main" || "$branch" == "master" || "$branch" == "codex/dev" || "$branch" == "production" ]]; then
@@ -119,7 +129,7 @@ fi
 enforce_corrected_kernel_gate_for_story() {
   local story_id="$1"
   local epic_id="${story_id%%-*}"
-  local status_file="_bmad-output/implementation-artifacts/sprint-status.yaml"
+  local status_file="$lane_sprint_status_file"
   local workflow_hint="dev-story"
 
   if [[ "$event" == "pull_request" ]]; then
@@ -161,6 +171,19 @@ enforce_corrected_kernel_gate_for_story() {
 }
 
 if [[ -n "$story_branch_id" ]]; then
+  if [[ "$branch" =~ ^codex/story-${story_branch_id}-(.+)$ ]]; then
+    story_branch_slug="${BASH_REMATCH[1]}"
+    if [[ "-$story_branch_slug-" != *-"$LANE_SLUG_TOKEN"-* ]]; then
+      echo "Policy check failed: story branch slug must include project lane token '$LANE_SLUG_TOKEN'"
+      echo "Expected branch pattern: codex/story-${story_branch_id}-${LANE_SLUG_TOKEN}-<slug>"
+      echo "Current branch: $branch"
+      echo "Resolved project lane: $ACTIVE_LANE"
+      print_policy_context
+      print_recovery "dev-story"
+      exit 1
+    fi
+  fi
+
   enforce_corrected_kernel_gate_for_story "$story_branch_id"
 fi
 

--- a/scripts/project-lane-context.js
+++ b/scripts/project-lane-context.js
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function fail(message) {
+  process.stderr.write(`Project lane context failed: ${message}\n`);
+  process.exit(1);
+}
+
+function normalizeLaneId(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeSlugToken(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '')
+    .replace(/-+/g, '-');
+}
+
+function parseArgs(argv) {
+  const args = {
+    lane: '',
+    branch: '',
+    format: 'json',
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--lane') {
+      const value = argv[i + 1] || '';
+      if (!value || value.startsWith('--')) {
+        fail('missing value for --lane');
+      }
+      args.lane = normalizeLaneId(value);
+      i += 1;
+      continue;
+    }
+    if (token === '--branch') {
+      const value = argv[i + 1] || '';
+      if (!value || value.startsWith('--')) {
+        fail('missing value for --branch');
+      }
+      args.branch = String(value).trim();
+      i += 1;
+      continue;
+    }
+    if (token === '--format') {
+      const value = argv[i + 1] || '';
+      if (!value || value.startsWith('--')) {
+        fail('missing value for --format');
+      }
+      const format = String(value).trim().toLowerCase();
+      if (format !== 'json' && format !== 'shell') {
+        fail(`unsupported format '${value}'`);
+      }
+      args.format = format;
+      i += 1;
+      continue;
+    }
+    if (token === '-h' || token === '--help') {
+      process.stdout.write(
+        'Usage: node scripts/project-lane-context.js [--lane <lane-id>] [--branch <branch>] [--format json|shell]\n'
+      );
+      process.exit(0);
+    }
+    fail(`unknown argument '${token}'`);
+  }
+
+  return args;
+}
+
+function loadConfig(repoRoot) {
+  const configPath = path.join(repoRoot, 'docs/policies/project_lanes.json');
+  if (!fs.existsSync(configPath)) {
+    fail(`missing config file: ${path.relative(repoRoot, configPath)}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (error) {
+    fail(`could not parse config file: ${error.message}`);
+  }
+
+  if (!parsed || !Array.isArray(parsed.lanes) || parsed.lanes.length === 0) {
+    fail('config must define a non-empty "lanes" array');
+  }
+
+  const lanes = [];
+  const laneById = new Map();
+  for (const rawLane of parsed.lanes) {
+    const id = normalizeLaneId(rawLane && rawLane.id);
+    if (!id) {
+      fail('each lane must define a non-empty "id"');
+    }
+    if (laneById.has(id)) {
+      fail(`duplicate lane id '${id}'`);
+    }
+    const sprintStatusFile = String(rawLane.sprintStatusFile || '').trim();
+    if (!sprintStatusFile) {
+      fail(`lane '${id}' is missing sprintStatusFile`);
+    }
+    const branchTokens = Array.isArray(rawLane.branchTokens)
+      ? rawLane.branchTokens.map((token) => normalizeLaneId(token)).filter(Boolean)
+      : [];
+
+    const lane = {
+      id,
+      sprintStatusFile: sprintStatusFile.replace(/\\/g, '/').replace(/^\.\//, ''),
+      branchTokens,
+    };
+    lanes.push(lane);
+    laneById.set(id, lane);
+  }
+
+  const defaultLane = normalizeLaneId(parsed.defaultLane);
+  if (!defaultLane) {
+    fail('config must define defaultLane');
+  }
+  if (!laneById.has(defaultLane)) {
+    fail(`defaultLane '${defaultLane}' is not present in lanes[]`);
+  }
+
+  return {
+    lanes,
+    laneById,
+    defaultLane,
+  };
+}
+
+function normalizeRelativePath(value) {
+  return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '').trim();
+}
+
+function inferLaneFromBranch(config, branch) {
+  const normalizedBranch = normalizeLaneId(branch);
+  if (!normalizedBranch) {
+    return '';
+  }
+  const matched = new Set();
+  for (const lane of config.lanes) {
+    for (const token of lane.branchTokens) {
+      if (!token) {
+        continue;
+      }
+      if (normalizedBranch.includes(token)) {
+        matched.add(lane.id);
+      }
+    }
+  }
+  if (matched.size > 1) {
+    fail(
+      `branch '${branch}' matches multiple lanes: ${Array.from(matched)
+        .sort()
+        .join(', ')}`
+    );
+  }
+  if (matched.size === 1) {
+    return Array.from(matched)[0];
+  }
+  return '';
+}
+
+function inferLaneFromSprintStatus(config, repoRoot, statusFilePath) {
+  const candidateRaw = normalizeRelativePath(statusFilePath);
+  if (!candidateRaw) {
+    return '';
+  }
+  const candidateAbsolute = path.resolve(path.isAbsolute(candidateRaw) ? candidateRaw : path.join(repoRoot, candidateRaw));
+  const matches = config.lanes.filter((lane) => {
+    const laneAbsolute = path.resolve(repoRoot, lane.sprintStatusFile);
+    return laneAbsolute === candidateAbsolute;
+  });
+
+  if (matches.length > 1) {
+    fail(
+      `sprint status file '${statusFilePath}' matches multiple lanes: ${matches
+        .map((lane) => lane.id)
+        .join(', ')}`
+    );
+  }
+  if (matches.length === 1) {
+    return matches[0].id;
+  }
+  return '';
+}
+
+function resolveLane(config, args) {
+  const envLane = normalizeLaneId(process.env.PROJECT_LANE || '');
+  const requestedLane = normalizeLaneId(args.lane || envLane);
+  if (requestedLane) {
+    const lane = config.laneById.get(requestedLane);
+    if (!lane) {
+      fail(`unknown lane '${requestedLane}'`);
+    }
+    return {
+      lane,
+      source: args.lane ? 'arg' : 'env',
+    };
+  }
+
+  const inferredLaneId = inferLaneFromBranch(config, args.branch || '');
+  if (inferredLaneId) {
+    return {
+      lane: config.laneById.get(inferredLaneId),
+      source: 'branch',
+    };
+  }
+
+  const sprintStatusLaneId = inferLaneFromSprintStatus(
+    config,
+    process.cwd(),
+    process.env.SPRINT_STATUS_FILE || ''
+  );
+  if (sprintStatusLaneId) {
+    return {
+      lane: config.laneById.get(sprintStatusLaneId),
+      source: 'sprint-status-file',
+    };
+  }
+
+  return {
+    lane: config.laneById.get(config.defaultLane),
+    source: 'default',
+  };
+}
+
+function shQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function printShell(payload) {
+  const lines = [
+    `ACTIVE_LANE=${shQuote(payload.activeLane)}`,
+    `DEFAULT_LANE=${shQuote(payload.defaultLane)}`,
+    `LANE_SOURCE=${shQuote(payload.source)}`,
+    `LANE_SLUG_TOKEN=${shQuote(payload.slugToken)}`,
+    `LANE_SPRINT_STATUS_FILE=${shQuote(payload.sprintStatusFile)}`,
+  ];
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const args = parseArgs(process.argv);
+  const config = loadConfig(repoRoot);
+  const { lane, source } = resolveLane(config, args);
+  const slugToken = normalizeSlugToken(lane.id);
+  if (!slugToken) {
+    fail(`lane '${lane.id}' produced an empty slug token`);
+  }
+
+  const payload = {
+    activeLane: lane.id,
+    defaultLane: config.defaultLane,
+    source,
+    slugToken,
+    sprintStatusFile: lane.sprintStatusFile,
+  };
+
+  if (args.format === 'shell') {
+    printShell(payload);
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+main();

--- a/scripts/start-story-branch.sh
+++ b/scripts/start-story-branch.sh
@@ -2,17 +2,27 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 [--allow-dirty] <story-id> <slug>"
+  echo "Usage: $0 [--allow-dirty] [--lane <lane-id>] <story-id> <slug>"
   echo "Example: $0 0-1 canonical-app-entrypoint-and-platform-middleware-chain"
+  echo "Example: $0 --lane connectshyft 1-1 admin-user-creation-ui"
   echo "Example: $0 --allow-dirty 0-1 canonical-app-entrypoint-and-platform-middleware-chain"
 }
 
 allow_dirty=false
+lane_override=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --allow-dirty)
       allow_dirty=true
       shift
+      ;;
+    --lane)
+      if [[ $# -lt 2 || -z "${2-}" || "${2-}" == --* ]]; then
+        echo "Missing value for --lane"
+        exit 1
+      fi
+      lane_override="$2"
+      shift 2
       ;;
     -h|--help)
       usage
@@ -39,7 +49,18 @@ if [[ ! "$story_id" =~ ^[0-9]+-[0-9]+$ ]]; then
 fi
 
 epic_id="${story_id%%-*}"
-status_file="_bmad-output/implementation-artifacts/sprint-status.yaml"
+current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+
+lane_context_args=(--format shell --branch "${current_branch:-detached}")
+if [[ -n "$lane_override" ]]; then
+  lane_context_args+=(--lane "$lane_override")
+fi
+if ! lane_context="$(node scripts/project-lane-context.js "${lane_context_args[@]}")"; then
+  exit 1
+fi
+eval "$lane_context"
+
+status_file="${SPRINT_STATUS_FILE:-$LANE_SPRINT_STATUS_FILE}"
 
 if [[ "$epic_id" != "0" ]]; then
   if [[ ! -f "$status_file" ]]; then
@@ -70,6 +91,10 @@ slug="$(echo "$slug_raw" \
 if [[ -z "$slug" ]]; then
   echo "Slug cannot be empty after normalization"
   exit 1
+fi
+
+if [[ "-$slug-" != *-"$LANE_SLUG_TOKEN"-* ]]; then
+  slug="${LANE_SLUG_TOKEN}-${slug}"
 fi
 
 branch="codex/story-${story_id}-${slug}"

--- a/tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.api.spec.ts
+++ b/tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.api.spec.ts
@@ -101,7 +101,7 @@ test.describe('Story 1.5 policy gate and branch workflow guard enforcement API c
   test('[P0] rejects story workflow branch mismatch with exact expected pattern diagnostics @P0', async ({
     story15Context,
   }) => {
-    const mismatchedBranch = 'codex/story-1-4-shared-response-envelope-and-refusal-helpers';
+    const mismatchedBranch = 'codex/story-1-4-routeshyft-shared-response-envelope-and-refusal-helpers';
     const { output, status } = runBranchWorkflowGuardInTempRepo(story15Context.branchGuardScript, {
       branch: mismatchedBranch,
       workflow: '_bmad/tea/workflows/testarch/automate/workflow.yaml',
@@ -109,7 +109,7 @@ test.describe('Story 1.5 policy gate and branch workflow guard enforcement API c
     });
 
     const hasFailurePrefix = /Branch guard failed/.test(output);
-    const hasExpectedPattern = /Expected branch pattern:\s*codex\/story-1-5-<slug>/.test(output);
+    const hasExpectedPattern = /Expected branch pattern:\s*codex\/story-1-5-routeshyft-<slug>/.test(output);
     const hasCurrentBranch = new RegExp(`Current branch:\\s*${escapeRegex(mismatchedBranch)}`).test(output);
 
     expect(status !== 0 && hasFailurePrefix && hasExpectedPattern && hasCurrentBranch).toBe(true);
@@ -125,7 +125,7 @@ test.describe('Story 1.5 policy gate and branch workflow guard enforcement API c
       baseRef: 'codex/dev',
       commitSubject: 'bad subject format',
       simulatePullRequestMergeCommit: true,
-      prMergeSubject: 'Merge pull request #15 from codex/story-1-5-policy-gate-and-branch-workflow-guard-enforcement',
+      prMergeSubject: 'Merge pull request #15 from codex/story-1-5-routeshyft-policy-gate-and-branch-workflow-guard-enforcement',
       seedFiles: {
         '_bmad-output/implementation-artifacts/sprint-status.yaml': FEATURE_STORY_SPRINT_STATUS,
       },

--- a/tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.atdd.api.spec.ts
+++ b/tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.atdd.api.spec.ts
@@ -97,14 +97,14 @@ test.describe('Story 1.5 Policy Gate and Branch Workflow Guard Enforcement (ATDD
     '[P0] enforces story workflow branch alignment for ATDD and reports exact expected branch pattern on mismatch @P0',
     async ({ story15Context }) => {
       const { output, status } = runBranchWorkflowGuardInTempRepo(story15Context.branchGuardScript, {
-        branch: 'codex/story-1-4-shared-response-envelope-and-refusal-helpers',
+        branch: 'codex/story-1-4-routeshyft-shared-response-envelope-and-refusal-helpers',
         workflow: '_bmad/tea/workflows/testarch/atdd/workflow.yaml',
         story: story15Context.storyFile,
       });
 
       const hasFailurePrefix = /Branch guard failed/.test(output);
-      const hasExpectedPattern = /Expected branch pattern:\s*codex\/story-1-5-<slug>/.test(output);
-      const hasCurrentBranch = /Current branch:\s*codex\/story-1-4-shared-response-envelope-and-refusal-helpers/.test(
+      const hasExpectedPattern = /Expected branch pattern:\s*codex\/story-1-5-routeshyft-<slug>/.test(output);
+      const hasCurrentBranch = /Current branch:\s*codex\/story-1-4-routeshyft-shared-response-envelope-and-refusal-helpers/.test(
         output,
       );
 
@@ -116,14 +116,14 @@ test.describe('Story 1.5 Policy Gate and Branch Workflow Guard Enforcement (ATDD
     story15Context,
   }) => {
     const { output, status } = runBranchWorkflowGuardInTempRepo(story15Context.branchGuardScript, {
-      branch: 'codex/story-1-5-policy-gate-and-branch-workflow-guard-enforcement',
+      branch: 'codex/story-1-5-routeshyft-policy-gate-and-branch-workflow-guard-enforcement',
       workflow: 'sprint-planning',
       epic: '1',
     });
 
     const hasFailurePrefix = /Branch guard failed/.test(output);
     const hasExpectedBranch = /Expected branch:\s*codex\/epic-1-ops/.test(output);
-    const hasCurrentBranch = /Current branch:\s*codex\/story-1-5-policy-gate-and-branch-workflow-guard-enforcement/.test(
+    const hasCurrentBranch = /Current branch:\s*codex\/story-1-5-routeshyft-policy-gate-and-branch-workflow-guard-enforcement/.test(
       output,
     );
 

--- a/tests/api/platform/ci-policy-gate-as-blocking-first-stage.api.spec.ts
+++ b/tests/api/platform/ci-policy-gate-as-blocking-first-stage.api.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { test, expect } from '../../support/fixtures/ciPolicyContext.fixture';
@@ -18,7 +18,7 @@ type BranchGuardHarnessOptions = {
 };
 
 const FEATURE_STORY_ID = '1-1';
-const FEATURE_STORY_BRANCH = 'codex/story-1-1-tenant-context-resolution-and-isolation-guardrails';
+const FEATURE_STORY_BRANCH = 'codex/story-1-1-routeshyft-tenant-context-resolution-and-isolation-guardrails';
 const FEATURE_STORY_FILE =
   '_bmad-output/implementation-artifacts/1-1-tenant-context-resolution-and-isolation-guardrails.md';
 
@@ -39,6 +39,7 @@ function runBranchGuardInTempRepo(
   const repoDir = mkdtempSync(join(tmpdir(), 'branch-guard-harness-'));
   const sprintStatusPath = join(repoDir, '_bmad-output/implementation-artifacts/sprint-status.yaml');
   const branchGuardAbsolutePath = resolve(branchGuardScript);
+  const sourceRepoRoot = resolve(dirname(branchGuardAbsolutePath), '..');
   const branch = options.branch ?? FEATURE_STORY_BRANCH;
   const workflow = options.workflow ?? 'dev-story';
   const story = options.story ?? FEATURE_STORY_FILE;
@@ -47,6 +48,20 @@ function runBranchGuardInTempRepo(
     mkdirSync(dirname(sprintStatusPath), { recursive: true });
     writeFileSync(sprintStatusPath, sprintStatusContents, 'utf8');
     writeFileSync(join(repoDir, 'README.md'), '# branch guard harness\n', 'utf8');
+
+    const laneContextScriptSource = join(sourceRepoRoot, 'scripts/project-lane-context.js');
+    const laneContextScriptTarget = join(repoDir, 'scripts/project-lane-context.js');
+    if (existsSync(laneContextScriptSource)) {
+      mkdirSync(dirname(laneContextScriptTarget), { recursive: true });
+      copyFileSync(laneContextScriptSource, laneContextScriptTarget);
+    }
+
+    const laneConfigSource = join(sourceRepoRoot, 'docs/policies/project_lanes.json');
+    const laneConfigTarget = join(repoDir, 'docs/policies/project_lanes.json');
+    if (existsSync(laneConfigSource)) {
+      mkdirSync(dirname(laneConfigTarget), { recursive: true });
+      copyFileSync(laneConfigSource, laneConfigTarget);
+    }
 
     execFileSync('git', ['init', '-b', 'main'], { cwd: repoDir, stdio: 'ignore' });
     execFileSync('git', ['config', 'user.email', 'branch-guard-harness@example.com'], { cwd: repoDir, stdio: 'ignore' });
@@ -97,7 +112,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
     const { output, status } = runPolicyScriptInTempRepo(ciPolicyContext.policyScript, ciPolicyContext.policyFile, {
       branch: 'main',
       event: 'local',
-      headRef: 'codex/story-9-9-spoofed-branch',
+      headRef: 'codex/story-9-9-routeshyft-spoofed-branch',
       commitSubject: '9-9: spoof attempt',
     });
 
@@ -118,7 +133,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
         env: {
           ...process.env,
           GITHUB_EVENT_NAME: 'pull_request',
-          GITHUB_HEAD_REF: 'codex/story-0-9-ci-policy-gate-as-blocking-first-stage',
+          GITHUB_HEAD_REF: 'codex/story-0-9-routeshyft-ci-policy-gate-as-blocking-first-stage',
           GITHUB_BASE_REF: 'production',
         },
         encoding: 'utf8',
@@ -130,7 +145,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
 
     // Then output should include explicit branch and base context for remediation
     const hasFailureHeadline = /Policy check failed: story pull requests must target codex\/dev/.test(output);
-    const hasHeadBranchContext = /Head branch:\s*codex\/story-0-9-ci-policy-gate-as-blocking-first-stage/.test(
+    const hasHeadBranchContext = /Head branch:\s*codex\/story-0-9-routeshyft-ci-policy-gate-as-blocking-first-stage/.test(
       output,
     );
     const hasBaseBranchContext = /Base branch:\s*production/.test(output);
@@ -175,7 +190,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
       execFileSync('bash', [ciPolicyContext.branchGuardScript, '--workflow', 'automate'], {
         env: {
           ...process.env,
-          GITHUB_HEAD_REF: 'codex/story-0-9-ci-policy-gate-as-blocking-first-stage',
+          GITHUB_HEAD_REF: 'codex/story-0-9-routeshyft-ci-policy-gate-as-blocking-first-stage',
         },
         encoding: 'utf8',
       });
@@ -192,7 +207,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
     ciPolicyContext,
   }) => {
     // Given a local repository branch that does not match the requested story id
-    const mismatchedBranch = 'codex/story-0-8-centralized-time-service-and-utc-local-rendering-contract';
+    const mismatchedBranch = 'codex/story-0-8-routeshyft-centralized-time-service-and-utc-local-rendering-contract';
     const { output, status } = runBranchGuardInTempRepo(
       ciPolicyContext.branchGuardScript,
       createSprintStatus('done', 'approved'),
@@ -204,7 +219,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
     );
 
     // When reading guard failure diagnostics
-    const hasExpectedPattern = /Expected branch pattern:\s*codex\/story-0-9-<slug>/.test(output);
+    const hasExpectedPattern = /Expected branch pattern:\s*codex\/story-0-9-routeshyft-<slug>/.test(output);
     const hasCurrentBranch = new RegExp(`Current branch:\\s*${mismatchedBranch}`).test(output);
 
     // Then output should include concrete branch mismatch diagnostics
@@ -222,7 +237,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
         branch: 'main',
         story: '_bmad-output/implementation-artifacts/0-9-ci-policy-gate-as-blocking-first-stage.md',
         env: {
-          GITHUB_HEAD_REF: 'codex/story-0-9-ci-policy-gate-as-blocking-first-stage',
+          GITHUB_HEAD_REF: 'codex/story-0-9-routeshyft-ci-policy-gate-as-blocking-first-stage',
         },
       },
     );
@@ -240,7 +255,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
     const { output, status } = runPolicyScriptInTempRepo(ciPolicyContext.policyScript, ciPolicyContext.policyFile, {
       branch: 'codex/dev',
       event: 'local',
-      headRef: 'codex/story-0-9-ignored-in-local-mode',
+      headRef: 'codex/story-0-9-routeshyft-ignored-in-local-mode',
       commitSubject: '0-9: local default branch run',
     });
 
@@ -256,7 +271,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
   test('[P1] story branches require matching commit subject story id @P1', async ({ ciPolicyContext }) => {
     // Given a story branch with a mismatched latest commit subject story id
     const { output, status } = runPolicyScriptInTempRepo(ciPolicyContext.policyScript, ciPolicyContext.policyFile, {
-      branch: 'codex/story-0-9-ci-policy-gate-as-blocking-first-stage',
+      branch: 'codex/story-0-9-routeshyft-ci-policy-gate-as-blocking-first-stage',
       event: 'local',
       commitSubject: '0-8: wrong story commit subject',
     });

--- a/tests/api/platform/ci-policy-gate-as-blocking-first-stage.api.spec.ts
+++ b/tests/api/platform/ci-policy-gate-as-blocking-first-stage.api.spec.ts
@@ -300,7 +300,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
     // Then CI policy should block workflow progression with explicit corrected-kernel context
     const hasGateFailureMessage = /corrected kernel gate unmet \(Story 0-10 is not done\)/.test(output);
     const hasPolicyReference = /Policy reference:\s*docs\/policies\/git_policy\.md/.test(output);
-    const hasRemediationHint = /npm run branch:ensure-workflow -- --workflow code-review --story _bmad-output\/implementation-artifacts\/1-1-tenant-context-resolution-and-isolation-guardrails\.md/.test(
+    const hasRemediationHint = /npm run branch:ensure-workflow -- --workflow code-review --story _bmad-output\/implementation-artifacts\/1-1-routeshyft-tenant-context-resolution-and-isolation-guardrails\.md/.test(
       output,
     );
     expect(status !== 0 && hasGateFailureMessage && hasPolicyReference && hasRemediationHint).toBe(true);
@@ -326,7 +326,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage API cover
       output,
     );
     const hasPolicyReference = /Policy reference:\s*docs\/policies\/git_policy\.md/.test(output);
-    const hasRemediationHint = /npm run branch:ensure-workflow -- --workflow code-review --story _bmad-output\/implementation-artifacts\/1-1-tenant-context-resolution-and-isolation-guardrails\.md/.test(
+    const hasRemediationHint = /npm run branch:ensure-workflow -- --workflow code-review --story _bmad-output\/implementation-artifacts\/1-1-routeshyft-tenant-context-resolution-and-isolation-guardrails\.md/.test(
       output,
     );
     expect(status !== 0 && hasCourseCorrectionFailure && hasPolicyReference && hasRemediationHint).toBe(true);

--- a/tests/e2e/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.atdd.spec.ts
+++ b/tests/e2e/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.atdd.spec.ts
@@ -23,7 +23,7 @@ test.describe('Story 1.5 Policy Gate and Branch Workflow Guard Enforcement (ATDD
         /npm run start:story-branch -- <story-id> <story-slug>/.test(policyResult.output) &&
         /Policy reference:\s*docs\/policies\/git_policy\.md/.test(policyResult.output);
       const branchGuardIncludesPatternAndCurrent =
-        /Expected branch pattern:\s*codex\/story-1-5-<slug>/.test(branchGuardResult.output) &&
+        /Expected branch pattern:\s*codex\/story-1-5-routeshyft-<slug>/.test(branchGuardResult.output) &&
         /Current branch:\s*main/.test(branchGuardResult.output);
 
       expect(

--- a/tests/e2e/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.spec.ts
+++ b/tests/e2e/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.spec.ts
@@ -30,7 +30,7 @@ test.describe('Story 1.5 policy and branch guard maintainer journeys', () => {
       /Policy reference:\s*docs\/policies\/git_policy\.md/.test(policyResult.output) &&
       /npm run start:story-branch -- <story-id> <story-slug>/.test(policyResult.output);
     const branchGuardHasPatternAndCurrent =
-      /Expected branch pattern:\s*codex\/story-1-5-<slug>/.test(branchGuardResult.output) &&
+      /Expected branch pattern:\s*codex\/story-1-5-routeshyft-<slug>/.test(branchGuardResult.output) &&
       /Current branch:\s*main/.test(branchGuardResult.output);
 
     expect(

--- a/tests/e2e/platform/ci-policy-gate-as-blocking-first-stage.spec.ts
+++ b/tests/e2e/platform/ci-policy-gate-as-blocking-first-stage.spec.ts
@@ -128,7 +128,7 @@ test.describe('Story 0.9 atdd - ci policy gate as blocking first stage', () => {
     const { output, status } = runPolicyScriptInTempRepo(ciPolicyContext.policyScript, ciPolicyContext.policyFile, {
       branch: 'main',
       event: 'local',
-      headRef: 'codex/story-0-9-ignored-in-local-mode',
+      headRef: 'codex/story-0-9-routeshyft-ignored-in-local-mode',
       commitSubject: '0-9: local policy failure path',
     });
 

--- a/tests/support/factories/kernelReadinessContextFactory.ts
+++ b/tests/support/factories/kernelReadinessContextFactory.ts
@@ -40,7 +40,7 @@ export function createKernelReadinessContext(
     storyId: '0-10',
     routeStoryFile:
       '_bmad-output/implementation-artifacts/1-1-tenant-context-resolution-and-isolation-guardrails.md',
-    routeStoryBranch: 'codex/story-1-1-tenant-context-resolution-and-isolation-guardrails',
+    routeStoryBranch: 'codex/story-1-1-routeshyft-tenant-context-resolution-and-isolation-guardrails',
     routeWorkflow: 'dev-story',
     qualityGateScript: 'scripts/quality-gates-epic0.sh',
     branchGuardScript: 'scripts/branch-ensure-workflow.sh',

--- a/tests/support/factories/policyWorkflowGuardStory15Factory.ts
+++ b/tests/support/factories/policyWorkflowGuardStory15Factory.ts
@@ -19,7 +19,7 @@ export function createPolicyWorkflowGuardStory15Context(
     policyFile: 'docs/policies/git_policy.md',
     storyId: '1-5',
     storyFile: '_bmad-output/implementation-artifacts/1-5-policy-gate-and-branch-workflow-guard-enforcement.md',
-    storyBranch: 'codex/story-1-5-policy-gate-and-branch-workflow-guard-enforcement',
+    storyBranch: 'codex/story-1-5-routeshyft-policy-gate-and-branch-workflow-guard-enforcement',
     epicBranch: 'codex/epic-1-ops',
     ...overrides,
   };

--- a/tests/support/utils/branchWorkflowGuardTestHarness.ts
+++ b/tests/support/utils/branchWorkflowGuardTestHarness.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -25,6 +25,7 @@ export function runBranchWorkflowGuardInTempRepo(
 ): BranchWorkflowGuardHarnessResult {
   const repoDir = mkdtempSync(join(tmpdir(), 'branch-workflow-guard-harness-'));
   const branchGuardAbsolutePath = resolve(branchGuardScriptPath);
+  const sourceRepoRoot = resolve(dirname(branchGuardAbsolutePath), '..');
   const sprintStatusPath = join(repoDir, '_bmad-output/implementation-artifacts/sprint-status.yaml');
   const phase0StatusPath = join(repoDir, '_bmad-output/implementation-artifacts/phase0-readiness.json');
 
@@ -32,6 +33,20 @@ export function runBranchWorkflowGuardInTempRepo(
     writeFileSync(join(repoDir, 'README.md'), '# branch workflow guard harness\n', 'utf8');
     mkdirSync(dirname(sprintStatusPath), { recursive: true });
     mkdirSync(dirname(phase0StatusPath), { recursive: true });
+
+    const laneContextScriptSource = join(sourceRepoRoot, 'scripts/project-lane-context.js');
+    const laneContextScriptTarget = join(repoDir, 'scripts/project-lane-context.js');
+    if (existsSync(laneContextScriptSource)) {
+      mkdirSync(dirname(laneContextScriptTarget), { recursive: true });
+      copyFileSync(laneContextScriptSource, laneContextScriptTarget);
+    }
+
+    const laneConfigSource = join(sourceRepoRoot, 'docs/policies/project_lanes.json');
+    const laneConfigTarget = join(repoDir, 'docs/policies/project_lanes.json');
+    if (existsSync(laneConfigSource)) {
+      mkdirSync(dirname(laneConfigTarget), { recursive: true });
+      copyFileSync(laneConfigSource, laneConfigTarget);
+    }
 
     writeFileSync(
       sprintStatusPath,

--- a/tests/support/utils/policyScriptTestHarness.ts
+++ b/tests/support/utils/policyScriptTestHarness.ts
@@ -140,6 +140,10 @@ export function runPolicyScriptInTempRepo(
       join(repoDir, 'scripts/enforce-project-lane.js'),
     );
     copyFileIfPresent(
+      join(scriptsDir, 'project-lane-context.js'),
+      join(repoDir, 'scripts/project-lane-context.js'),
+    );
+    copyFileIfPresent(
       join(docsPoliciesDir, 'project_lanes.json'),
       join(repoDir, 'docs/policies/project_lanes.json'),
     );


### PR DESCRIPTION
## Summary
- enforce story branch slug contract as `codex/story-<story-id>-<project-lane>-<slug>`
- add reusable lane resolver (`scripts/project-lane-context.js`) so lane token comes from lane config/context, not hardcoded module names
- make `start-story-branch`, `branch:ensure-workflow`, and `policy:check` lane-aware for slug validation and sprint status selection
- update policy docs and harness/spec fixtures for the lane-token branch pattern

## Validation
- `bash -n scripts/start-story-branch.sh scripts/branch-ensure-workflow.sh scripts/enforce-git-policy.sh`
- `npx playwright test tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.api.spec.ts --grep "rejects story workflow branch mismatch"`
- `npx playwright test tests/api/platform/ci-policy-gate-as-blocking-first-stage.api.spec.ts --grep "actionable branch context"`
- `npx playwright test tests/api/platform/ci-policy-gate-as-blocking-first-stage.api.spec.ts --grep "branch workflow guard failure output includes exact expected pattern"`
- `npx playwright test tests/api/platform/ci-policy-gate-as-blocking-first-stage.api.spec.ts --grep "story branches require matching commit subject story id"`
- `npx playwright test tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.api.spec.ts --grep "pull_request policy checks validate PR head subject"`
- `npx playwright test tests/e2e/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.spec.ts --grep "maintainer on valid story branch passes"`
