### PR TITLE
Fix: standardize localhost:5174 test target and preflight validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 TEST_ENV=local
-BASE_URL=http://localhost:5173
-API_URL=http://localhost:3001
+BASE_URL=http://localhost:5174
+API_URL=http://localhost:3000
 TEST_EMAIL=test@example.com
 TEST_PASSWORD=change-me
 ENABLE_TEST_AUTH_HARNESS=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,11 +82,11 @@ jobs:
       ENABLE_TEST_AUTH_HARNESS: 'true'
       TEST_EMAIL: test@example.com
       TEST_PASSWORD: test1234
-      BASE_URL: http://127.0.0.1:5173
-      API_URL: http://127.0.0.1:3000
-      API_BASE_URL: http://127.0.0.1:3000
-      FRONTEND_URL: http://127.0.0.1:5173
-      VITE_API_PROXY_TARGET: http://127.0.0.1:3000
+      BASE_URL: http://localhost:5174
+      API_URL: http://localhost:3000
+      API_BASE_URL: http://localhost:3000
+      FRONTEND_URL: http://localhost:5174
+      VITE_API_PROXY_TARGET: http://localhost:3000
     strategy:
       fail-fast: false
       matrix:
@@ -149,11 +149,11 @@ jobs:
       ENABLE_TEST_AUTH_HARNESS: 'true'
       TEST_EMAIL: test@example.com
       TEST_PASSWORD: test1234
-      BASE_URL: http://127.0.0.1:5173
-      API_URL: http://127.0.0.1:3000
-      API_BASE_URL: http://127.0.0.1:3000
-      FRONTEND_URL: http://127.0.0.1:5173
-      VITE_API_PROXY_TARGET: http://127.0.0.1:3000
+      BASE_URL: http://localhost:5174
+      API_URL: http://localhost:3000
+      API_BASE_URL: http://localhost:3000
+      FRONTEND_URL: http://localhost:5174
+      VITE_API_PROXY_TARGET: http://localhost:3000
     steps:
       - uses: actions/checkout@v4
         with:

--- a/_bmad-output/test-artifacts/ci-pipeline-progress.md
+++ b/_bmad-output/test-artifacts/ci-pipeline-progress.md
@@ -1,0 +1,60 @@
+---
+stepsCompleted: ['step-01-preflight','step-02-generate-pipeline','step-03-configure-quality-gates','step-04-validate-and-summary']
+lastStep: 'step-04-validate-and-summary'
+lastSaved: '2026-02-21T22:22:15Z'
+---
+
+# CI Workflow Progress (connectshyft epic 1)
+
+> Team standard note: user testing and local Playwright runs are pinned to `http://localhost:5174` to avoid host/port mismatch.
+
+## Step 1: Preflight Checks
+- Git repository: present (`.git/` exists).
+- Git remote: configured (`origin` -> GitHub).
+- Test framework: Playwright detected (`playwright.config.ts`, `@playwright/test` in `package.json`).
+- Branch workflow guard for epic execution: passed.
+  - Command: `npm run branch:ensure-workflow -- --workflow _bmad/tea/workflows/testarch/ci/workflow.yaml --epic 1`
+- Node runtime source: `.nvmrc` found (`24`).
+- Local test gate: initially blocked in sandbox networking, now resolved.
+  - Initial failure: missing frontend deps (`vite` not installed).
+  - Resolution validation (host-level): `curl -sf http://localhost:5174/login` and `curl -sf http://localhost:3000/health` both succeeded.
+  - Preflight validation command (resolved): `BASE_URL=http://localhost:5174 API_URL=http://localhost:3000 AUTO_START_STACK=false npm run test:e2e -- --list` (exit code 0).
+
+## Step 2: Generate CI Pipeline
+- Existing CI pipeline detected at `/Users/jeremiahotis/projects/connectshyft/.github/workflows/test.yml`.
+- Existing workflow already includes required staged architecture:
+  - `policy` (blocking first job)
+  - `lint`
+  - `test` (4 shards, fail-fast false)
+  - `burn-in` (10 iterations)
+  - `quality-gates`
+  - `backend-contracts` (manual lane)
+  - `report`
+- Artifact collection and retention are configured across test/burn-in/quality stages.
+- Decision: no scaffold replacement needed.
+
+## Step 3: Quality Gates & Notifications
+- Loaded TEA knowledge index and `ci-burn-in` guidance.
+- Current pipeline quality gates align with TEA requirements and repo policy:
+  - P0/P1 gates enforced via `scripts/quality-gates.sh`
+  - burn-in gating configured for PR/scheduled runs
+  - report summary generated on every run
+- Failure notification hook is present via optional Slack webhook in `report` job.
+
+## Step 4: Validate & Summary
+### Validation Results
+- CI config file exists and is structurally valid.
+- Stages and sharding are configured.
+- Burn-in and artifact collection are configured.
+- Secrets/variables are documented in workflow env references.
+- Remaining blocker: none for localhost reachability preflight validation.
+
+### Completion Summary
+- CI platform: GitHub Actions
+- Config path: `/Users/jeremiahotis/projects/connectshyft/.github/workflows/test.yml`
+- Key stages enabled: policy -> lint -> test(4 shards) -> burn-in -> quality-gates -> optional backend-contracts -> report
+- Artifacts: shard artifacts, burn-in artifacts, quality-gates artifacts
+- Notifications: optional Slack webhook on failure
+
+### Recommended Next Action
+- Optional follow-up: run full suite with `BASE_URL=http://localhost:5174 npm run test:e2e`.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
     ['json', { outputFile: 'tests/artifacts/test-results/results.json' }],
   ],
   use: {
-    baseURL: process.env.BASE_URL || 'http://127.0.0.1:5173',
+    baseURL: process.env.BASE_URL || 'http://localhost:5174',
     actionTimeout: 15_000,
     navigationTimeout: 30_000,
     trace: 'retain-on-failure',

--- a/scripts/ci-run-playwright-stack.sh
+++ b/scripts/ci-run-playwright-stack.sh
@@ -18,13 +18,15 @@ export TEST_ENV="${TEST_ENV:-local}"
 export TEST_EMAIL="${TEST_EMAIL:-test@example.com}"
 export TEST_PASSWORD="${TEST_PASSWORD:-test1234}"
 export ENABLE_TEST_AUTH_HARNESS="${ENABLE_TEST_AUTH_HARNESS:-true}"
-export BASE_URL="${BASE_URL:-http://127.0.0.1:5173}"
-export API_URL="${API_URL:-http://127.0.0.1:3000}"
+export BASE_URL="${BASE_URL:-http://localhost:5174}"
+export API_URL="${API_URL:-http://localhost:3000}"
 export API_BASE_URL="${API_BASE_URL:-$API_URL}"
-export FRONTEND_URL="${FRONTEND_URL:-http://127.0.0.1:5173}"
-export VITE_API_PROXY_TARGET="${VITE_API_PROXY_TARGET:-http://127.0.0.1:3000}"
-export HOST="${HOST:-127.0.0.1}"
+export FRONTEND_URL="${FRONTEND_URL:-http://localhost:5174}"
+export VITE_API_PROXY_TARGET="${VITE_API_PROXY_TARGET:-http://localhost:3000}"
+export HOST="${HOST:-localhost}"
 export PORT="${PORT:-3000}"
+frontend_host="$(node -e "const u = new URL(process.argv[1]); process.stdout.write(u.hostname);" "$BASE_URL")"
+frontend_port="$(node -e "const u = new URL(process.argv[1]); process.stdout.write(u.port || '5174');" "$BASE_URL")"
 
 print_runtime_logs() {
   echo "==== Backend log tail ===="
@@ -107,11 +109,11 @@ echo "Starting backend dev server"
 BACKEND_PID=$!
 
 echo "Starting frontend dev server"
-(cd frontend && npm run dev -- --host 127.0.0.1 --port 5173) > "$frontend_log" 2>&1 &
+(cd frontend && npm run dev -- --host "$frontend_host" --port "$frontend_port") > "$frontend_log" 2>&1 &
 FRONTEND_PID=$!
 
-wait_for_http "http://127.0.0.1:3000/health" "backend health endpoint"
-wait_for_http "http://127.0.0.1:5173/login" "frontend login page"
+wait_for_http "${API_URL%/}/health" "backend health endpoint"
+wait_for_http "${BASE_URL%/}/login" "frontend login page"
 
 echo "Running test command: $*"
 "$@"

--- a/scripts/run-playwright-with-preflight.sh
+++ b/scripts/run-playwright-with-preflight.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-API_URL="${API_URL:-http://127.0.0.1:3000}"
-BASE_URL="${BASE_URL:-http://127.0.0.1:5173}"
+API_URL="${API_URL:-http://localhost:3000}"
+BASE_URL="${BASE_URL:-http://localhost:5174}"
 AUTO_START_STACK="${AUTO_START_STACK:-true}"
 RUNTIME_DIR="${RUNTIME_DIR:-tests/artifacts/runtime}"
 BACKEND_LOG_FILE="${RUNTIME_DIR}/backend.log"
@@ -21,14 +21,15 @@ FRONTEND_PID=""
 BACKEND_STARTED=false
 FRONTEND_STARTED=false
 
-validate_loopback_host() {
+validate_allowed_host() {
   local url="$1"
   local label="$2"
+  local allowed_hosts="$3"
 
   local host
   host="$(node -e "const u = new URL(process.argv[1]); process.stdout.write(u.hostname);" "$url")"
-  if [[ "$host" != "127.0.0.1" ]]; then
-    echo "Playwright preflight failed: $label must use host 127.0.0.1 (got: $url)"
+  if [[ ! ",$allowed_hosts," == *",$host,"* ]]; then
+    echo "Playwright preflight failed: $label must use one of [$allowed_hosts] (got: $url)"
     exit 1
   fi
 }
@@ -114,11 +115,13 @@ on_exit() {
 }
 trap on_exit EXIT
 
-validate_loopback_host "$API_URL" "API_URL"
-validate_loopback_host "$BASE_URL" "BASE_URL"
+validate_allowed_host "$API_URL" "API_URL" "localhost,127.0.0.1"
+validate_allowed_host "$BASE_URL" "BASE_URL" "localhost"
 
 api_root="${API_URL%/}"
 frontend_root="${BASE_URL%/}"
+frontend_host="$(node -e "const u = new URL(process.argv[1]); process.stdout.write(u.hostname);" "$BASE_URL")"
+frontend_port="$(node -e "const u = new URL(process.argv[1]); process.stdout.write(u.port || '5174');" "$BASE_URL")"
 
 if ! is_http_reachable "$api_root/health" && ! is_http_reachable "$api_root/api/v1/health"; then
   if [[ "$AUTO_START_STACK" != "true" ]]; then
@@ -151,7 +154,7 @@ if ! is_http_reachable "$frontend_root/login" && ! is_http_reachable "$frontend_
 
   echo "Managed runtime policy: starting frontend for this test run"
   : > "$FRONTEND_LOG_FILE"
-  (cd frontend && VITE_API_PROXY_TARGET="$API_URL" npm run dev -- --host 127.0.0.1 --port 5173 --strictPort) >"$FRONTEND_LOG_FILE" 2>&1 &
+  (cd frontend && VITE_API_PROXY_TARGET="$API_URL" npm run dev -- --host "$frontend_host" --port "$frontend_port" --strictPort) >"$FRONTEND_LOG_FILE" 2>&1 &
   FRONTEND_PID=$!
   FRONTEND_STARTED=true
   echo "$FRONTEND_PID" > "$FRONTEND_PID_FILE"

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,7 @@
 
 ## Running Tests
 
+- Canonical local user-testing target: `http://localhost:5174` (do not switch to `127.0.0.1:5173`).
 - Headless:
   `npm run test:e2e`
 - Headed:
@@ -73,7 +74,7 @@
 
 ## Troubleshooting
 
-- If base URL is wrong, set `BASE_URL` in `.env`.
+- If base URL is wrong, set `BASE_URL=http://localhost:5174` in `.env`.
 - If auth tests fail, verify `TEST_EMAIL` and `TEST_PASSWORD`.
 - Open HTML report with:
   `npx playwright show-report tests/artifacts/playwright-report`


### PR DESCRIPTION
## Summary
- standardize local/user-testing frontend target to `http://localhost:5174`
- update Playwright defaults and runtime scripts to stop host/port drift
- align CI env defaults with `localhost:5174` and `localhost:3000`
- document the canonical testing target in test docs and env example
- record resolved TEA CI preflight validation evidence for localhost reachability

## Changed Files
- `.env.example`
- `.github/workflows/test.yml`
- `playwright.config.ts`
- `scripts/ci-run-playwright-stack.sh`
- `scripts/run-playwright-with-preflight.sh`
- `tests/README.md`
- `_bmad-output/test-artifacts/ci-pipeline-progress.md`

## Validation
- `curl -sf http://localhost:5174/login` -> success
- `curl -sf http://localhost:3000/health` -> success
- `BASE_URL=http://localhost:5174 API_URL=http://localhost:3000 AUTO_START_STACK=false npm run test:e2e -- --list` -> exit 0
