### PR TITLE
Fix: normalize API envelope helper naming to error

### DIFF
--- a/src/src/__tests__/apiEnvelopeContract.test.ts
+++ b/src/src/__tests__/apiEnvelopeContract.test.ts
@@ -185,7 +185,7 @@ describe('Story 0.5 - shared API envelope and business refusal contract', () => 
   });
 
   describe('shared system error contract helper', () => {
-    it('returns systemError envelope with explicit error type and status', async () => {
+    it('returns error envelope with explicit error type and status', async () => {
       const app = buildApp();
 
       const response = await request(app)

--- a/src/src/platform/envelopes/response.ts
+++ b/src/src/platform/envelopes/response.ts
@@ -20,7 +20,7 @@ type RefusalEnvelopeParams = {
   httpStatus?: number;
 };
 
-type SystemErrorEnvelopeParams = {
+type ErrorEnvelopeParams = {
   code: string;
   message: string;
   data?: unknown;
@@ -50,7 +50,7 @@ export type RefusalEnvelopePayload = {
   data?: unknown;
 };
 
-export type SystemErrorEnvelopePayload = {
+export type ErrorEnvelopePayload = {
   ok: false;
   code: string;
   message: string;
@@ -63,7 +63,7 @@ export type SystemErrorEnvelopePayload = {
 export type ApiEnvelopePayload =
   | SuccessEnvelopePayload
   | RefusalEnvelopePayload
-  | SystemErrorEnvelopePayload;
+  | ErrorEnvelopePayload;
 
 const resolveContext = (res: Response): EnvelopeContext => {
   const locals = res.locals as ResponseLocalsEnvelope;
@@ -124,10 +124,10 @@ export const buildRefusalEnvelope = (
   ...(data !== undefined ? { data } : {})
 });
 
-export const buildSystemErrorEnvelope = (
+export const buildErrorEnvelope = (
   context: EnvelopeContext,
-  { code, message, data }: Omit<SystemErrorEnvelopeParams, 'httpStatus'>
-): SystemErrorEnvelopePayload => ({
+  { code, message, data }: Omit<ErrorEnvelopeParams, 'httpStatus'>
+): ErrorEnvelopePayload => ({
   ok: false,
   code,
   message,
@@ -168,14 +168,17 @@ export const refusal = (
   return res.status(httpStatus).json(payload);
 };
 
-export const systemError = (
+export const error = (
   res: Response,
-  { httpStatus = 500, ...params }: SystemErrorEnvelopeParams
+  { httpStatus = 500, ...params }: ErrorEnvelopeParams
 ): Response => {
   const context = resolveContext(res);
-  const payload = buildSystemErrorEnvelope(context, params);
+  const payload = buildErrorEnvelope(context, params);
   return res.status(httpStatus).json(payload);
 };
+
+// Backward compatibility alias for legacy imports.
+export const systemError = error;
 
 export const replayEnvelope = (
   res: Response,

--- a/src/src/platform/middleware/responseEnvelope.ts
+++ b/src/src/platform/middleware/responseEnvelope.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 import {
   buildRefusalEnvelope,
   buildSuccessEnvelope,
-  buildSystemErrorEnvelope,
+  buildErrorEnvelope,
   EnvelopeContext,
   isEnvelopePayload
 } from '../envelopes/response';
@@ -52,7 +52,7 @@ export const responseEnvelope = (req: Request, res: Response, next: NextFunction
       const data = extractData(body);
 
       if (statusCode >= 500) {
-        const payload = buildSystemErrorEnvelope(context, {
+        const payload = buildErrorEnvelope(context, {
           code,
           message,
           ...(data !== undefined ? { data } : {})

--- a/src/src/routes/api/v1/auth.ts
+++ b/src/src/routes/api/v1/auth.ts
@@ -6,7 +6,7 @@ import { setAuthCookies, clearAuthCookies, verifyRefreshToken, generateAccessTok
 import { validateRequest } from '../../../middleware/validate';
 import { signupSchema, loginSchema } from '../../../validators/auth.validators';
 import { authenticateToken } from '../../../middleware/auth';
-import { refusal, success, systemError } from '../../../platform/envelopes/response';
+import { refusal, success, error as errorEnvelope } from '../../../platform/envelopes/response';
 import logger from '../../../utils/logger';
 import PlatformSessionStore from '../../../platform/sessions/PlatformSessionStore';
 import { generateInvitationCode } from '../../../utils/invitationCode';
@@ -522,7 +522,7 @@ router.post('/password/first-login-reset', authenticateToken, async (req: Reques
       });
       return;
     }
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'FIRST_LOGIN_RESET_FAILED',
       message: 'Failed to reset password',
       httpStatus: 500,

--- a/src/src/routes/api/v1/platform-admin-console.ts
+++ b/src/src/routes/api/v1/platform-admin-console.ts
@@ -2,7 +2,7 @@ import { Request, Response, Router } from 'express';
 import { createHash, randomUUID } from 'crypto';
 import bcrypt from 'bcryptjs';
 import db from '../../../config/knex';
-import { refusal, success, systemError } from '../../../platform/envelopes/response';
+import { refusal, success, error as errorEnvelope } from '../../../platform/envelopes/response';
 import { CAPABILITIES, hasCapability } from '../../../platform/rbac/capabilities';
 import {
   ensureScopedAdminUser,
@@ -443,7 +443,7 @@ const ensureTenantAccess = async (
 
     return { tenantId, evaluation };
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'RBAC_EVALUATION_FAILED',
       message: error instanceof Error ? error.message : 'Failed to evaluate access',
       httpStatus: 500,
@@ -1148,7 +1148,7 @@ router.get('/tenants', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'TENANTS_LIST_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve tenants',
       httpStatus: 500,
@@ -1233,7 +1233,7 @@ router.get('/tenants/:tenantId', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'TENANT_DETAIL_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve tenant detail',
       httpStatus: 500,
@@ -1306,7 +1306,7 @@ router.patch('/tenants/:tenantId/modules', async (req: Request, res: Response) =
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'TENANT_MODULES_UPDATE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to update tenant modules',
         httpStatus: 500,
@@ -1386,7 +1386,7 @@ router.patch('/tenants/:tenantId/structure-rules', async (req: Request, res: Res
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'TENANT_STRUCTURE_RULES_UPDATE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to update tenant structure rules',
         httpStatus: 500,
@@ -1484,7 +1484,7 @@ router.post('/tenants/:tenantId/admins', async (req: Request, res: Response) => 
         return;
       }
 
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'TENANT_ADMIN_ASSIGN_FAILED',
         message: error instanceof Error ? error.message : 'Failed to assign tenant admin',
         httpStatus: 500,
@@ -1545,7 +1545,7 @@ router.delete('/tenants/:tenantId/admins/:userId', async (req: Request, res: Res
         data: { tenantId, userId },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'TENANT_ADMIN_REMOVE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to remove tenant admin',
         httpStatus: 500,
@@ -1607,7 +1607,7 @@ router.get('/users/global', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'GLOBAL_USERS_RESOLVE_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve global users',
       httpStatus: 500,
@@ -1639,7 +1639,7 @@ router.get('/structure/tree', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'STRUCTURE_TREE_RESOLVE_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve structure tree',
       httpStatus: 500,
@@ -1830,7 +1830,7 @@ router.post('/structure/nodes', async (req: Request, res: Response) => {
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'STRUCTURE_NODE_CREATE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to create structure node',
         httpStatus: 500,
@@ -1954,7 +1954,7 @@ router.patch('/structure/nodes/:nodeId', async (req: Request, res: Response) => 
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'STRUCTURE_NODE_UPDATE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to update structure node',
         httpStatus: 500,
@@ -2078,7 +2078,7 @@ router.post('/structure/nodes/move', async (req: Request, res: Response) => {
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'STRUCTURE_NODE_MOVE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to move structure nodes',
         httpStatus: 500,
@@ -2160,7 +2160,7 @@ router.post('/structure/nodes/:nodeId/archive', async (req: Request, res: Respon
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'STRUCTURE_NODE_ARCHIVE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to archive node',
         httpStatus: 500,
@@ -2265,7 +2265,7 @@ router.post('/structure/nodes/:nodeId/restore', async (req: Request, res: Respon
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'STRUCTURE_NODE_RESTORE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to restore node',
         httpStatus: 500,
@@ -2345,7 +2345,7 @@ router.post('/structure/nodes/:nodeId/admin', async (req: Request, res: Response
         return;
       }
 
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'STRUCTURE_NODE_ADMIN_ASSIGN_FAILED',
         message: error instanceof Error ? error.message : 'Failed to assign node admin',
         httpStatus: 500,
@@ -2429,7 +2429,7 @@ router.patch('/structure/nodes/:nodeId/modules', async (req: Request, res: Respo
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'NODE_MODULE_OVERRIDE_UPDATE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to update node module override',
         httpStatus: 500,
@@ -2509,7 +2509,7 @@ router.post('/structure/nodes/modules/bulk-toggle', async (req: Request, res: Re
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'BULK_MODULE_TOGGLE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to apply bulk module toggle',
         httpStatus: 500,
@@ -2625,7 +2625,7 @@ router.get('/people', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'TENANT_PEOPLE_RESOLVE_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve people',
       httpStatus: 500,
@@ -2740,7 +2740,7 @@ router.post('/people', async (req: Request, res: Response) => {
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'TENANT_PERSON_CREATE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to create person',
         httpStatus: 500,
@@ -2870,7 +2870,7 @@ router.patch('/people/:userId', async (req: Request, res: Response) => {
         },
       });
     } catch (error) {
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'TENANT_PERSON_UPDATE_FAILED',
         message: error instanceof Error ? error.message : 'Failed to update person',
         httpStatus: 500,
@@ -2926,7 +2926,7 @@ router.get('/integrity/summary', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'INTEGRITY_SUMMARY_RESOLVE_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve integrity summary',
       httpStatus: 500,
@@ -2969,7 +2969,7 @@ router.get('/integrity', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'INTEGRITY_ISSUES_RESOLVE_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve integrity issues',
       httpStatus: 500,
@@ -3175,7 +3175,7 @@ router.post('/integrity/fix', async (req: Request, res: Response) => {
         return;
       }
 
-      systemError(res, {
+      errorEnvelope(res, {
         code: 'INTEGRITY_FIX_FAILED',
         message: error instanceof Error ? error.message : 'Failed to apply integrity fix',
         httpStatus: 500,
@@ -3265,7 +3265,7 @@ router.get('/audit/events', async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    systemError(res, {
+    errorEnvelope(res, {
       code: 'AUDIT_EVENTS_RESOLVE_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve audit events',
       httpStatus: 500,

--- a/src/src/routes/api/v1/platform-admin.ts
+++ b/src/src/routes/api/v1/platform-admin.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from 'crypto';
 import bcrypt from 'bcryptjs';
 import db from '../../../config/knex';
 import { authenticateToken } from '../../../middleware/auth';
-import { refusal, replayEnvelope, success, systemError } from '../../../platform/envelopes/response';
+import { refusal, replayEnvelope, success, error as errorEnvelope } from '../../../platform/envelopes/response';
 import { CAPABILITIES, hasCapability } from '../../../platform/rbac/capabilities';
 import {
   createOrgUnit,
@@ -446,7 +446,7 @@ router.get('/users/lookup', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'SCOPED_USER_LOOKUP_FAILED',
       message: getMessage(error, 'Failed to execute scoped user lookup'),
       httpStatus: 500,
@@ -511,7 +511,7 @@ router.post('/users/inline-admin', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'INLINE_ADMIN_USER_RESOLUTION_FAILED',
       message: getMessage(error, 'Failed to resolve inline admin identity'),
       httpStatus: 500,
@@ -620,7 +620,7 @@ router.post('/tenants', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'TENANT_CREATE_FAILED',
       message: getMessage(error, 'Failed to create tenant'),
       httpStatus: 500,
@@ -687,7 +687,7 @@ router.put('/module-entitlements', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'MODULE_ENTITLEMENT_UPDATE_FAILED',
       message: getMessage(error, 'Failed to update tenant module entitlement'),
       httpStatus: 500,
@@ -740,7 +740,7 @@ router.post('/org-units', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'ORG_UNIT_CREATE_FAILED',
       message: getMessage(error, 'Failed to create org unit'),
       httpStatus: 500,
@@ -831,7 +831,7 @@ router.put('/org-units/:orgUnitId', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'ORG_UNIT_UPDATE_FAILED',
       message: getMessage(error, 'Failed to update org unit'),
       httpStatus: 500,
@@ -891,7 +891,7 @@ router.post('/tenant-memberships', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'TENANT_MEMBERSHIP_UPDATE_FAILED',
       message: getMessage(error, 'Failed to update tenant membership'),
       httpStatus: 500,
@@ -952,7 +952,7 @@ router.delete('/tenant-memberships', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'TENANT_MEMBERSHIP_REVOKE_FAILED',
       message: getMessage(error, 'Failed to revoke tenant membership'),
       httpStatus: 500,
@@ -1038,7 +1038,7 @@ router.post('/org-unit-memberships', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'ORG_UNIT_MEMBERSHIP_UPDATE_FAILED',
       message: getMessage(error, 'Failed to update org unit membership'),
       httpStatus: 500,
@@ -1116,7 +1116,7 @@ router.delete('/org-unit-memberships', async (req: Request, res: Response) => {
       return;
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'ORG_UNIT_MEMBERSHIP_REVOKE_FAILED',
       message: getMessage(error, 'Failed to revoke org unit membership'),
       httpStatus: 500,
@@ -1141,7 +1141,7 @@ router.get('/rbac/evaluate', async (req: Request, res: Response) => {
       data,
     });
   } catch (error) {
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'RBAC_EVALUATION_FAILED',
       message: getMessage(error, 'Failed to evaluate RBAC'),
       httpStatus: 500,

--- a/src/src/routes/api/v1/platform-contracts.ts
+++ b/src/src/routes/api/v1/platform-contracts.ts
@@ -8,7 +8,7 @@ import {
   buildSuccessEnvelope,
   refusal,
   success,
-  systemError,
+  error as errorEnvelope,
   type EnvelopeContext
 } from '../../../platform/envelopes/response';
 import {
@@ -275,7 +275,7 @@ const validateOrgUnitContextAccess = async (
   } catch (error) {
     return {
       ok: false,
-      response: systemError(res, {
+      response: errorEnvelope(res, {
         code: 'ORG_UNIT_ACCESS_VALIDATION_FAILED',
         message: error instanceof Error ? error.message : 'Failed to validate orgUnit access',
         httpStatus: 500,
@@ -889,7 +889,7 @@ router.post('/_kernel/contracts/envelope/system-error', (req: Request, res: Resp
     ? req.body.httpStatus
     : 500;
 
-  return systemError(res, {
+  return errorEnvelope(res, {
     code,
     message,
     data: req.body?.data,
@@ -929,12 +929,12 @@ router.post('/_kernel/contracts/envelope/response-matrix/business-refusal', (req
 router.post('/_kernel/contracts/envelope/response-matrix/system-error', (req: Request, res: Response) => {
   applyEnvelopeTenantOverride(req, res);
 
-  return systemError(res, {
+  return errorEnvelope(res, {
     code: 'ENVELOPE_SYSTEM_ERROR',
     message: 'Shared response envelope emitted system error contract',
     data: {
       probe: 'response-matrix-system-error',
-      helper: 'systemError',
+      helper: 'error',
       contractVersion: '1.4'
     },
     httpStatus: 500
@@ -1057,7 +1057,7 @@ router.get('/_kernel/contracts/identity/global-email-uniqueness', async (req: Re
       contract
     });
   } catch (error) {
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'GLOBAL_EMAIL_UNIQUENESS_CONTRACT_CHECK_FAILED',
       message: error instanceof Error ? error.message : 'Failed to evaluate global email uniqueness contract',
       httpStatus: 500
@@ -1960,7 +1960,7 @@ router.get('/_kernel/tenancy/diagnostics', async (req: Request, res: Response) =
       });
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'TENANCY_CONTEXT_RESOLUTION_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve tenancy context',
       httpStatus: 500,
@@ -2001,7 +2001,7 @@ router.get('/_kernel/tenancy/repository-check', async (req: Request, res: Respon
       });
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'TENANCY_CONTEXT_RESOLUTION_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve tenancy context',
       httpStatus: 500,
@@ -2098,7 +2098,7 @@ router.post('/_kernel/tenancy/repository-check', async (req: Request, res: Respo
       });
     }
 
-    return systemError(res, {
+    return errorEnvelope(res, {
       code: 'TENANCY_CONTEXT_RESOLUTION_FAILED',
       message: error instanceof Error ? error.message : 'Failed to resolve tenancy context',
       httpStatus: 500,


### PR DESCRIPTION
Summary:\n- normalize shared helper naming from systemError to error at call sites\n- keep backward compatibility by exporting systemError as an alias\n- update response envelope middleware to use buildErrorEnvelope\n- align envelope contract metadata and unit-test wording\n\nValidation:\n- npm run build --prefix src\n- npm test --prefix src -- src/__tests__/apiEnvelopeContract.test.ts --runInBand