### PR TITLE
Fix: close C.2 ensure idempotency review findings

### DIFF
--- a/_bmad-output/implementation-artifacts/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.md
+++ b/_bmad-output/implementation-artifacts/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.md
@@ -1,6 +1,6 @@
 # Story c.2: Thread Ensure Endpoint with Conflict-Safe Idempotency
 
-Status: ready-for-dev
+Status: in-progress
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -23,7 +23,7 @@ so that duplicate active threads are never created for the same neighbor context
 - Backend/API Implies Human Operability: yes
 - Frontend/Operator Usability Criteria Included: yes
 - Operability Pairing Notes: Existing-thread reuse must be deterministic and non-disruptive so operators do not see duplicate conversations.
-- Real-User Validation Evidence: Pending implementation. Validate concurrent create/open behavior from UI and API clients.
+- Real-User Validation Evidence: Pending critical-capability validation run. Record concrete UI/API operator evidence before closeout.
 - Real-User Validation Result: pending
 - Role-Admin UI Path: N/A
 - Role-Admin UI Path Verified: n/a
@@ -136,4 +136,3 @@ GPT-5 Codex
 ## Change Log
 
 - 2026-02-24: Created Story c.2 ready-for-dev context document.
-

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -58,7 +58,7 @@ development_status:
   epic-b-retrospective: optional
   epic-c: in-progress
   c-1-core-connectshyft-thread-schema-and-lifecycle-constraints: done
-  c-2-thread-ensure-endpoint-with-conflict-safe-idempotency: ready-for-dev
+  c-2-thread-ensure-endpoint-with-conflict-safe-idempotency: in-progress
   c-3-inbox-and-thread-detail-read-contracts: ready-for-dev
   c-4-claim-takeover-and-close-lifecycle-actions: ready-for-dev
   c-5-deterministic-escalation-scheduler-with-claim-only-reset: ready-for-dev

--- a/src/src/modules/connectshyft/__tests__/threads.test.ts
+++ b/src/src/modules/connectshyft/__tests__/threads.test.ts
@@ -1,4 +1,5 @@
 import {
+  AsyncConnectShyftThreadService,
   ConnectShyftThreadService,
   InMemoryConnectShyftThreadStore,
 } from '../threads';
@@ -315,5 +316,35 @@ describe('connectshyft thread persistence guards', () => {
     }
 
     expect(second.data.thread.threadId).toBe('thread-c1-second');
+  });
+});
+
+describe('connectshyft async thread service persistence guards', () => {
+  it('returns persistence unavailable refusal instead of in-memory ensure success when storage is missing', async () => {
+    const missingSchemaError = Object.assign(new Error('relation does not exist'), {
+      code: '42P01',
+    });
+    const store = {
+      ensureActiveThread: jest.fn().mockRejectedValue(missingSchemaError),
+      listDueThreads: jest.fn(),
+      transitionThreadState: jest.fn(),
+    } as any;
+
+    const service = new AsyncConnectShyftThreadService(store);
+    const result = await service.ensureThread({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-c1',
+      orgUnitId: 'org-connectshyft-c1-east',
+      neighborId: 'neighbor-connectshyft-c1-5001',
+      source: 'VOICE',
+      lastInboundCsNumberId: 'cs-inbound-c1-5001',
+      preferredOutboundCsNumberId: 'cs-outbound-c1-5001',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE',
+    });
+    expect(store.ensureActiveThread).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/src/routes/api/v1/connectshyft.ts
+++ b/src/src/routes/api/v1/connectshyft.ts
@@ -499,10 +499,18 @@ const parseThreadDueLimit = (req: Request): number => {
   return Math.min(Math.trunc(rawLimit), 250);
 };
 
+const parseThreadIdFromBody = (req: Request): string | null => {
+  if (typeof req.body?.threadId !== 'string') {
+    return null;
+  }
+
+  const normalized = req.body.threadId.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
 const parseThreadEnsureBody = (req: Request) => ({
   orgUnitId: parseOrgUnitIdFromBody(req),
   neighborId: typeof req.body?.neighborId === 'string' ? req.body.neighborId.trim() : '',
-  threadId: typeof req.body?.threadId === 'string' ? req.body.threadId.trim() : '',
   source: typeof req.body?.source === 'string' ? req.body.source : 'VOICE',
   forcedState: typeof req.body?.forcedState === 'string' ? req.body.forcedState : undefined,
   lastInboundCsNumberId: typeof req.body?.lastInboundCsNumberId === 'string'
@@ -1604,13 +1612,32 @@ router.post('/threads', async (req: Request, res: Response) => {
     return;
   }
 
+  const requestedThreadId = parseThreadIdFromBody(req);
+  if (requestedThreadId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_THREAD_ID_FORBIDDEN',
+      message: 'threadId is server-assigned and cannot be provided.',
+      refusalType: 'client',
+      httpStatus: 400,
+      data: {
+        fieldErrors: [
+          {
+            field: 'threadId',
+            reason: 'FORBIDDEN',
+            message: 'threadId is server-assigned and cannot be provided.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
   const requestedRole = resolveConnectShyftRequestedRole(req);
   const ensured = await connectShyftThreadServiceAsync.ensureThread({
     actorRoles: [requestedRole],
     tenantId: context.tenantId,
     orgUnitId: context.orgUnitId,
     neighborId: payload.neighborId,
-    threadId: payload.threadId || undefined,
     source: payload.source,
     forcedState: payload.forcedState,
     lastInboundCsNumberId: payload.lastInboundCsNumberId,

--- a/tests/api/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.api.spec.ts
+++ b/tests/api/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.api.spec.ts
@@ -2,11 +2,56 @@ import { apiRequest } from '../../support/helpers/apiClient';
 import { test, expect } from '../../support/fixtures/connectShyftStoryC1.fixture';
 
 const REQUIRED_ENVELOPE_KEYS = ['ok', 'code', 'message', 'correlationId', 'tenantId'];
+const createConnectShyftDbClient = () => {
+  const knexFactory = require('../../../src/node_modules/knex');
+  return knexFactory({
+    client: 'postgresql',
+    connection: {
+      host: process.env.TEST_DB_HOST || '127.0.0.1',
+      port: Number(process.env.TEST_DB_PORT || 5432),
+      database: process.env.TEST_DB_NAME || 'moneyshyft',
+      user: process.env.TEST_DB_USER || 'jeremiahotis',
+      password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
+    },
+    pool: {
+      min: 0,
+      max: 2,
+    },
+  });
+};
+const connectShyftDb = createConnectShyftDbClient();
+
+const countActiveThreadsForIdentity = async ({
+  tenantId,
+  orgUnitId,
+  neighborId,
+}: {
+  tenantId: string;
+  orgUnitId: string;
+  neighborId: string;
+}): Promise<number> => {
+  const counted = await connectShyftDb
+    .withSchema('connectshyft')
+    .table('cs_threads')
+    .where({
+      tenant_id: tenantId,
+      org_unit_id: orgUnitId,
+      neighbor_id: neighborId,
+    })
+    .andWhere('state', '<>', 'CLOSED')
+    .count<{ count: string | number }>({ count: '*' })
+    .first();
+
+  return Number(counted?.count ?? 0);
+};
 
 test.describe(
   'Story c.1 automate - core ConnectShyft thread schema and lifecycle API coverage',
   () => {
     test.describe.configure({ mode: 'serial' });
+    test.afterAll(async () => {
+      await connectShyftDb.destroy();
+    });
 
     test(
       '[P0] ensures thread create responses expose canonical UNCLAIMED state and required lifecycle metadata fields @P0',
@@ -51,18 +96,28 @@ test.describe(
         storyC1CreatePayload,
         storyC1DuplicatePayload,
       }) => {
+        const uniqueNeighborId = `${storyC1CreatePayload.neighborId}-contention-${Date.now().toString(36)}`;
+        const firstEnsurePayload = {
+          ...storyC1CreatePayload,
+          neighborId: uniqueNeighborId,
+        };
+        const secondEnsurePayload = {
+          ...storyC1DuplicatePayload,
+          neighborId: uniqueNeighborId,
+        };
+
         const [firstResponse, secondResponse] = await Promise.all([
           apiRequest(request, {
             method: 'POST',
             path: storyC1Context.paths.threadsCollection,
             headers: storyC1OperatorHeaders,
-            data: storyC1CreatePayload,
+            data: firstEnsurePayload,
           }),
           apiRequest(request, {
             method: 'POST',
             path: storyC1Context.paths.threadsCollection,
             headers: storyC1OperatorHeaders,
-            data: storyC1DuplicatePayload,
+            data: secondEnsurePayload,
           }),
         ]);
 
@@ -74,6 +129,13 @@ test.describe(
 
         expect(firstBody.data.thread.threadId).toBe(secondBody.data.thread.threadId);
         expect(secondBody.data.thread.state).toBe('UNCLAIMED');
+
+        const activeThreadCount = await countActiveThreadsForIdentity({
+          tenantId: storyC1Context.tenantId,
+          orgUnitId: storyC1Context.orgUnitId,
+          neighborId: uniqueNeighborId,
+        });
+        expect(activeThreadCount).toBe(1);
       },
     );
 
@@ -133,6 +195,39 @@ test.describe(
         });
         expect(body).not.toHaveProperty('data.sqlState');
         expect(body).not.toHaveProperty('data.constraint');
+      },
+    );
+
+    test(
+      '[P1] rejects client-supplied threadId to prevent caller-controlled thread identity assignment @P1',
+      async ({ request, storyC1Context, storyC1OperatorHeaders, storyC1CreatePayload }) => {
+        const response = await apiRequest(request, {
+          method: 'POST',
+          path: storyC1Context.paths.threadsCollection,
+          headers: storyC1OperatorHeaders,
+          data: {
+            ...storyC1CreatePayload,
+            neighborId: `${storyC1CreatePayload.neighborId}-threadid-${Date.now().toString(36)}`,
+            threadId: '11111111-1111-4111-8111-111111111111',
+          },
+        });
+
+        expect(response.status()).toBe(400);
+        const body = await response.json();
+        expect(body).toMatchObject({
+          ok: false,
+          code: 'CONNECTSHYFT_THREAD_ID_FORBIDDEN',
+          refusalType: 'client',
+          data: {
+            fieldErrors: [
+              expect.objectContaining({
+                field: 'threadId',
+                reason: 'FORBIDDEN',
+              }),
+            ],
+          },
+        });
+        expect(body).not.toHaveProperty('data.thread');
       },
     );
 

--- a/tests/api/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.api.spec.ts
+++ b/tests/api/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.api.spec.ts
@@ -147,6 +147,16 @@ test.describe(
           neighborId: uniqueNeighborId,
         });
         expect(activeThreadCount).toBe(1);
+
+        await connectShyftDb
+          .withSchema('connectshyft')
+          .table('cs_threads')
+          .where({
+            tenant_id: storyC1Context.tenantId,
+            org_unit_id: storyC1Context.orgUnitId,
+            neighbor_id: uniqueNeighborId,
+          })
+          .del();
       },
     );
 

--- a/tests/api/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.api.spec.ts
+++ b/tests/api/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.api.spec.ts
@@ -2,17 +2,28 @@ import { apiRequest } from '../../support/helpers/apiClient';
 import { test, expect } from '../../support/fixtures/connectShyftStoryC1.fixture';
 
 const REQUIRED_ENVELOPE_KEYS = ['ok', 'code', 'message', 'correlationId', 'tenantId'];
+const resolveConnectShyftDbConnection = () => {
+  const databaseUrl =
+    process.env.MONEYSHYFT_TEST_DATABASE_URL
+    || (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
+  if (databaseUrl) {
+    return databaseUrl;
+  }
+
+  return {
+    host: process.env.TEST_DB_HOST || '127.0.0.1',
+    port: Number(process.env.TEST_DB_PORT || 5432),
+    database: process.env.TEST_DB_NAME || 'moneyshyft',
+    user: process.env.TEST_DB_USER || 'jeremiahotis',
+    password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
+  };
+};
+
 const createConnectShyftDbClient = () => {
   const knexFactory = require('../../../src/node_modules/knex');
   return knexFactory({
     client: 'postgresql',
-    connection: {
-      host: process.env.TEST_DB_HOST || '127.0.0.1',
-      port: Number(process.env.TEST_DB_PORT || 5432),
-      database: process.env.TEST_DB_NAME || 'moneyshyft',
-      user: process.env.TEST_DB_USER || 'jeremiahotis',
-      password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
-    },
+    connection: resolveConnectShyftDbConnection(),
     pool: {
       min: 0,
       max: 2,

--- a/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
+++ b/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
@@ -1,0 +1,97 @@
+import { apiRequest } from '../../support/helpers/apiClient';
+import { test, expect } from '../../support/fixtures/connectShyftStoryC1.fixture';
+
+const createConnectShyftDbClient = () => {
+  const knexFactory = require('../../../src/node_modules/knex');
+  return knexFactory({
+    client: 'postgresql',
+    connection: {
+      host: process.env.TEST_DB_HOST || '127.0.0.1',
+      port: Number(process.env.TEST_DB_PORT || 5432),
+      database: process.env.TEST_DB_NAME || 'moneyshyft',
+      user: process.env.TEST_DB_USER || 'jeremiahotis',
+      password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
+    },
+    pool: {
+      min: 0,
+      max: 2,
+    },
+  });
+};
+
+const connectShyftDb = createConnectShyftDbClient();
+
+const countActiveThreadsForIdentity = async ({
+  tenantId,
+  orgUnitId,
+  neighborId,
+}: {
+  tenantId: string;
+  orgUnitId: string;
+  neighborId: string;
+}): Promise<number> => {
+  const counted = await connectShyftDb
+    .withSchema('connectshyft')
+    .table('cs_threads')
+    .where({
+      tenant_id: tenantId,
+      org_unit_id: orgUnitId,
+      neighbor_id: neighborId,
+    })
+    .andWhere('state', '<>', 'CLOSED')
+    .count<{ count: string | number }>({ count: '*' })
+    .first();
+
+  return Number(counted?.count ?? 0);
+};
+
+test.describe(
+  'Story c.2 automate - thread ensure endpoint conflict-safe idempotency',
+  () => {
+    test.describe.configure({ mode: 'serial' });
+    test.afterAll(async () => {
+      await connectShyftDb.destroy();
+    });
+
+    test(
+      '[P0] concurrent ensure requests converge to one active thread row and one thread identity @P0',
+      async ({ request, storyC1Context, storyC1OperatorHeaders, storyC1CreatePayload }) => {
+        const uniqueNeighborId = `${storyC1CreatePayload.neighborId}-c2-${Date.now().toString(36)}`;
+        const ensurePayload = {
+          ...storyC1CreatePayload,
+          neighborId: uniqueNeighborId,
+        };
+
+        const [firstResponse, secondResponse] = await Promise.all([
+          apiRequest(request, {
+            method: 'POST',
+            path: storyC1Context.paths.threadsCollection,
+            headers: storyC1OperatorHeaders,
+            data: ensurePayload,
+          }),
+          apiRequest(request, {
+            method: 'POST',
+            path: storyC1Context.paths.threadsCollection,
+            headers: storyC1OperatorHeaders,
+            data: ensurePayload,
+          }),
+        ]);
+
+        expect(firstResponse.status()).toBe(201);
+        expect(secondResponse.status()).toBe(201);
+
+        const firstBody = await firstResponse.json();
+        const secondBody = await secondResponse.json();
+
+        expect(firstBody.data.thread.threadId).toBe(secondBody.data.thread.threadId);
+
+        const activeThreadCount = await countActiveThreadsForIdentity({
+          tenantId: storyC1Context.tenantId,
+          orgUnitId: storyC1Context.orgUnitId,
+          neighborId: uniqueNeighborId,
+        });
+        expect(activeThreadCount).toBe(1);
+      },
+    );
+  },
+);

--- a/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
+++ b/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
@@ -102,6 +102,16 @@ test.describe(
           neighborId: uniqueNeighborId,
         });
         expect(activeThreadCount).toBe(1);
+
+        await connectShyftDb
+          .withSchema('connectshyft')
+          .table('cs_threads')
+          .where({
+            tenant_id: storyC1Context.tenantId,
+            org_unit_id: storyC1Context.orgUnitId,
+            neighbor_id: uniqueNeighborId,
+          })
+          .del();
       },
     );
   },

--- a/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
+++ b/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
@@ -1,17 +1,28 @@
 import { apiRequest } from '../../support/helpers/apiClient';
 import { test, expect } from '../../support/fixtures/connectShyftStoryC1.fixture';
 
+const resolveConnectShyftDbConnection = () => {
+  const databaseUrl =
+    process.env.MONEYSHYFT_TEST_DATABASE_URL
+    || (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
+  if (databaseUrl) {
+    return databaseUrl;
+  }
+
+  return {
+    host: process.env.TEST_DB_HOST || '127.0.0.1',
+    port: Number(process.env.TEST_DB_PORT || 5432),
+    database: process.env.TEST_DB_NAME || 'moneyshyft',
+    user: process.env.TEST_DB_USER || 'jeremiahotis',
+    password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
+  };
+};
+
 const createConnectShyftDbClient = () => {
   const knexFactory = require('../../../src/node_modules/knex');
   return knexFactory({
     client: 'postgresql',
-    connection: {
-      host: process.env.TEST_DB_HOST || '127.0.0.1',
-      port: Number(process.env.TEST_DB_PORT || 5432),
-      database: process.env.TEST_DB_NAME || 'moneyshyft',
-      user: process.env.TEST_DB_USER || 'jeremiahotis',
-      password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
-    },
+    connection: resolveConnectShyftDbConnection(),
     pool: {
       min: 0,
       max: 2,

--- a/tests/e2e/platform/a-5-capability-based-route-access-and-envelope-contract-compliance.atdd.spec.ts
+++ b/tests/e2e/platform/a-5-capability-based-route-access-and-envelope-contract-compliance.atdd.spec.ts
@@ -102,7 +102,6 @@ test.describe(
           headers: adminHeaders,
           data: {
             orgUnitId: context.orgUnitId,
-            threadId: context.threadId,
             neighborId: 'neighbor-a5-envelope-success',
           },
         });

--- a/tests/e2e/platform/a-5-capability-based-route-access-and-envelope-contract-compliance.spec.ts
+++ b/tests/e2e/platform/a-5-capability-based-route-access-and-envelope-contract-compliance.spec.ts
@@ -101,7 +101,6 @@ test.describe(
           headers: storyA5OrgUnitAdminHeaders,
           data: {
             orgUnitId: storyA5Context.orgUnitId,
-            threadId: storyA5Context.threadId,
             neighborId: 'neighbor-a5-envelope-success',
           },
         });

--- a/tests/e2e/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.spec.ts
+++ b/tests/e2e/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
 import { login } from '../../helpers/auth';
 import { apiRequest } from '../../support/helpers/apiClient';
 import {
@@ -9,7 +10,22 @@ import {
 
 const REQUIRED_ENVELOPE_KEYS = ['ok', 'code', 'message', 'correlationId', 'tenantId'];
 
-const buildInboxUrl = (context: StoryC1Context, actorUserId: string): string => {
+const createIsolatedStoryC1Context = (): StoryC1Context => {
+  const suffix = randomUUID().slice(0, 8);
+  return createStoryC1Context({
+    neighborId: `neighbor-connectshyft-c1-${suffix}`,
+  });
+};
+
+const buildInboxUrl = (
+  context: StoryC1Context,
+  actorUserId: string,
+  threadContext?: {
+    neighborId: string;
+    lastInboundCsNumberId: string;
+    preferredOutboundCsNumberId: string;
+  },
+): string => {
   const params = new URLSearchParams({
     flags: 'module:on,inbox:on,escalation:on,webhooks:on',
     tenantId: context.tenantId,
@@ -17,12 +33,35 @@ const buildInboxUrl = (context: StoryC1Context, actorUserId: string): string => 
     tenantRole: 'ORGUNIT_MEMBER',
     orgUnitMemberships: context.orgUnitId,
     actorUserId,
+    neighborId: threadContext?.neighborId || context.neighborId,
+    lastInboundCsNumberId: threadContext?.lastInboundCsNumberId || context.inboundCsNumberId,
+    preferredOutboundCsNumberId:
+      threadContext?.preferredOutboundCsNumberId || context.preferredOutboundCsNumberId,
   });
 
   return context.paths.inboxUi + '?' + params.toString();
 };
 
-const ensureThread = async (request: APIRequestContext, context: StoryC1Context): Promise<void> => {
+const ensureThread = async (
+  request: APIRequestContext,
+  context: StoryC1Context,
+  threadContext?: {
+    neighborId?: string;
+    lastInboundCsNumberId?: string;
+    preferredOutboundCsNumberId?: string;
+  },
+): Promise<{
+  neighborId: string;
+  lastInboundCsNumberId: string;
+  preferredOutboundCsNumberId: string;
+}> => {
+  const resolvedThreadContext = {
+    neighborId: threadContext?.neighborId || context.neighborId,
+    lastInboundCsNumberId: threadContext?.lastInboundCsNumberId || context.inboundCsNumberId,
+    preferredOutboundCsNumberId:
+      threadContext?.preferredOutboundCsNumberId || context.preferredOutboundCsNumberId,
+  };
+
   const operatorHeaders = createStoryC1Headers(context, {
     orgUnitMemberships: [context.orgUnitId],
   });
@@ -33,14 +72,15 @@ const ensureThread = async (request: APIRequestContext, context: StoryC1Context)
     headers: operatorHeaders,
     data: {
       orgUnitId: context.orgUnitId,
-      neighborId: context.neighborId,
+      neighborId: resolvedThreadContext.neighborId,
       source: 'VOICE',
-      lastInboundCsNumberId: context.inboundCsNumberId,
-      preferredOutboundCsNumberId: context.preferredOutboundCsNumberId,
+      lastInboundCsNumberId: resolvedThreadContext.lastInboundCsNumberId,
+      preferredOutboundCsNumberId: resolvedThreadContext.preferredOutboundCsNumberId,
     },
   });
 
   expect(ensureResponse.status()).toBe(201);
+  return resolvedThreadContext;
 };
 
 test.describe(
@@ -51,43 +91,67 @@ test.describe(
     test(
       '[P0] inbox renders canonical UNCLAIMED thread state with required number metadata after ensure flow @P0',
       async ({ page, request }) => {
-        const context = createStoryC1Context();
-        await ensureThread(request, context);
+        const context = createIsolatedStoryC1Context();
+        const suffix = randomUUID().slice(0, 8);
+        const threadContext = await ensureThread(request, context, {
+          lastInboundCsNumberId: `cs-inbound-c1-${suffix}`,
+          preferredOutboundCsNumberId: `cs-outbound-c1-${suffix}`,
+        });
 
         await login(page);
-        await page.goto(buildInboxUrl(context, context.userId));
+        await page.goto(buildInboxUrl(context, context.userId, threadContext));
 
         await expect(page.getByRole('heading', { name: 'ConnectShyft Inbox' })).toBeVisible();
-        await expect(page.getByTestId('connectshyft-thread-card')).toContainText('UNCLAIMED');
-        await expect(page.getByTestId('connectshyft-thread-last-inbound-number')).toContainText(
-          context.inboundCsNumberId,
-        );
-        await expect(page.getByTestId('connectshyft-thread-preferred-outbound-number')).toContainText(
-          context.preferredOutboundCsNumberId,
-        );
+        const targetCard = page
+          .getByTestId('connectshyft-thread-card')
+          .filter({ hasText: threadContext.lastInboundCsNumberId });
+        await expect(targetCard).toHaveCount(1);
+        await expect(targetCard).toContainText('UNCLAIMED');
+        await expect(
+          targetCard.getByTestId('connectshyft-thread-last-inbound-number'),
+        ).toContainText(threadContext.lastInboundCsNumberId);
+        await expect(
+          targetCard.getByTestId('connectshyft-thread-preferred-outbound-number'),
+        ).toContainText(threadContext.preferredOutboundCsNumberId);
       },
     );
 
     test(
       '[P0] duplicate open interactions keep a single active thread card for the same neighbor tuple @P0',
-      async ({ page }) => {
-        const context = createStoryC1Context();
+      async ({ page, request }) => {
+        const context = createIsolatedStoryC1Context();
+        const suffix = randomUUID().slice(0, 8);
+        const threadContext = await ensureThread(request, context, {
+          lastInboundCsNumberId: `cs-inbound-c1-${suffix}`,
+          preferredOutboundCsNumberId: `cs-outbound-c1-${suffix}`,
+        });
         await login(page);
 
-        await page.goto(buildInboxUrl(context, context.userId));
+        await page.goto(buildInboxUrl(context, context.userId, threadContext));
         await page.getByRole('button', { name: 'Open Conversation' }).click();
         await page.reload();
         await page.getByRole('button', { name: 'Open Conversation' }).click();
 
-        await expect(page.getByTestId('connectshyft-thread-card')).toHaveCount(1);
-        await expect(page.getByTestId('connectshyft-thread-state-chip')).toHaveText('UNCLAIMED');
+        const targetCard = page
+          .getByTestId('connectshyft-thread-card')
+          .filter({ hasText: threadContext.lastInboundCsNumberId });
+        await expect(targetCard).toHaveCount(1);
+        await expect(
+          targetCard.getByTestId('connectshyft-thread-state-chip'),
+        ).toHaveText('UNCLAIMED');
       },
     );
 
     test(
       '[P1] journey-level contracts keep canonical envelope keys across ensure refusal and due-thread scheduler paths @P1',
       async ({ request }) => {
-        const context = createStoryC1Context();
+        const context = createIsolatedStoryC1Context();
+        const suffix = randomUUID().slice(0, 8);
+        const threadContext = {
+          neighborId: context.neighborId,
+          lastInboundCsNumberId: `cs-inbound-c1-${suffix}`,
+          preferredOutboundCsNumberId: `cs-outbound-c1-${suffix}`,
+        };
 
         const operatorHeaders = createStoryC1Headers(context, {
           orgUnitMemberships: [context.orgUnitId],
@@ -107,10 +171,10 @@ test.describe(
           headers: operatorHeaders,
           data: {
             orgUnitId: context.orgUnitId,
-            neighborId: context.neighborId,
+            neighborId: threadContext.neighborId,
             source: 'VOICE',
-            lastInboundCsNumberId: context.inboundCsNumberId,
-            preferredOutboundCsNumberId: context.preferredOutboundCsNumberId,
+            lastInboundCsNumberId: threadContext.lastInboundCsNumberId,
+            preferredOutboundCsNumberId: threadContext.preferredOutboundCsNumberId,
           },
         });
         const refusalResponse = await apiRequest(request, {
@@ -119,7 +183,7 @@ test.describe(
           headers: operatorHeaders,
           data: {
             orgUnitId: context.orgUnitId,
-            neighborId: context.neighborId,
+            neighborId: threadContext.neighborId,
             forcedState: 'PAUSED',
             source: 'VOICE',
           },


### PR DESCRIPTION
Summary
- Harden POST /api/v1/connectshyft/threads by rejecting client-supplied threadId and preventing caller-controlled persistence IDs.
- Add async thread-service guard test proving missing persistence returns CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE with no in-memory success fallback.
- Strengthen contention evidence with DB cardinality assertions and add dedicated C.2 API contention spec.
- Align C.2 story artifacts to in-progress while critical real-user validation remains pending.

Validation
- npm test -- src/src/modules/connectshyft/__tests__/threads.test.ts
- npm run test:e2e -- tests/api/platform/c-1-core-connectshyft-thread-schema-and-lifecycle-constraints.api.spec.ts tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
- npm run test:e2e -- tests/api/platform/a-2-tenant-and-orgunit-context-enforcement-for-connectshyft-routes.api.spec.ts tests/api/platform/a-5-capability-based-route-access-and-envelope-contract-compliance.api.spec.ts
- npm run test:e2e -- tests/e2e/platform/a-5-capability-based-route-access-and-envelope-contract-compliance.spec.ts tests/e2e/platform/a-5-capability-based-route-access-and-envelope-contract-compliance.atdd.spec.ts
- npm run story:status:check -- --story-key c-2-thread-ensure-endpoint-with-conflict-safe-idempotency --lane connectshyft